### PR TITLE
Address Linear connector MVP readiness gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Contract v1. It requires a Harn version that includes
 [harn#464](https://github.com/burin-labs/harn/issues/464) and
 [harn#468](https://github.com/burin-labs/harn/issues/468).
 
-Linear has no OpenAPI spec — its public API is GraphQL. A typed
-`linear-sdk-harn` would be a separate, GraphQL-codegen-based effort and is
-not bundled here.
+Linear has no OpenAPI spec: its public API is GraphQL. For v0.1 this package
+keeps a small hand-written GraphQL helper layer in `src/lib.harn` instead of
+introducing a separate `linear-sdk-harn` package. That keeps the connector
+self-contained while still giving the production methods argument validation,
+stable query documents, mocked tests, and one shared error/rate-limit path.
 
 ## Install
 
@@ -60,6 +62,78 @@ trigger triage on linear {
 }
 ```
 
+## Configuration
+
+Inbound webhooks require the Linear webhook signing secret. The connector
+checks `raw.signing_secret`, `raw.metadata.signing_secret`,
+`binding.config.signing_secret`, or `binding.config.secrets.signing_secret`;
+otherwise it reads `linear/signing-secret` through `secret_get`.
+
+Outbound calls require one of:
+
+- `access_token` or `access_token_secret` for OAuth tokens. Requests use
+  `Authorization: Bearer <token>`.
+- `api_key` or `api_key_secret` for personal API keys. Requests use
+  `Authorization: <api_key>`.
+
+Use OAuth for workspace/user integrations and personal API keys only for local
+scripts or private automation. Minimum OAuth scopes depend on the methods used:
+
+- `read` for `list_issues`, `search`, and read-only `graphql` queries.
+- `write` or narrower write scopes for mutations.
+- `comments:create` is enough for `create_comment`.
+- `issues:create` is only needed if future recipes add issue creation.
+- Avoid `admin`; this connector does not require it for the MVP methods.
+
+## Inbound Events
+
+Supported Linear webhook resources are:
+
+- `Issue` -> `linear.issue.<action>`
+- `Comment` / `IssueComment` -> `linear.comment.<action>`
+- `IssueLabel` -> `linear.issue_label.<action>`
+- `Project` / `ProjectUpdate` -> `linear.project.<action>`
+- `Cycle` -> `linear.cycle.<action>`
+- `Customer` -> `linear.customer.<action>`
+- `CustomerRequest` -> `linear.customer_request.<action>`
+
+Actions are `create`, `update`, and `remove`. Unknown resources are normalized
+with their lower-case resource name; unknown actions are rejected. Dedupe keys
+prefer `Linear-Delivery`, then `webhookId`, then `sha256(raw_body)`.
+
+## Outbound Methods
+
+`call("graphql", args)` is the escape hatch. It accepts `query`, optional
+`variables`, optional `operation_name` / `operationName`, auth, and optional
+`api_base_url`.
+
+Typed MVP helpers are local to this package:
+
+- `list_issues({ filter?, first?, after?, include_archived? })`
+- `update_issue({ id, changes })`
+- `create_comment({ issue_id, body })`
+- `search({ query, first? })`
+
+Connection-returning methods preserve Linear pagination data in `pageInfo`.
+Callers should pass `pageInfo.endCursor` as `after` while
+`pageInfo.hasNextPage` is true. `search` uses Linear's `searchIssues` field and
+falls back from the newer `query` argument to the older `term` argument when
+Linear returns a GraphQL validation error.
+
+GraphQL responses always include `meta` on success. Typed helper return objects
+also receive this `meta` field:
+
+- `observed_complexity`
+- `complexity_estimate` as a best-effort local hint
+- `complexity_warning`
+- `rate_limit.requests_*`
+- `rate_limit.complexity_*`
+
+GraphQL errors throw structured objects. Partial data is preserved on
+`error.data`, GraphQL errors are preserved on `error.errors`, and rate-limit
+responses are classified as `error.code == "rate_limited"` when Linear returns
+HTTP 429 or a GraphQL error with `extensions.code == "RATELIMITED"`.
+
 ## Development
 
 The connector exports `provider_id`, `kinds`, `payload_schema`, `init`,
@@ -78,6 +152,7 @@ Dedupe keys are deterministic. The connector prefers `Linear-Delivery`, then
 Run the local contract and fixture suite with:
 
 ```sh
+harn --version
 harn check src/lib.harn
 harn lint src/lib.harn
 harn fmt --check src/lib.harn
@@ -85,6 +160,11 @@ harn connector check .
 for test in tests/*.harn; do harn run "$test"; done
 ```
 
+CI installs the pinned Harn CLI from `.harn-version` via
+`cargo install harn-cli --version "$(cat .harn-version)" --locked`, then runs
+the same checks plus a clean package-install smoke. Local development should use
+the installed CLI and this package's `harn.toml`; it should not depend on a
+sibling `~/projects/harn` checkout.
 
 ## License
 

--- a/harn.toml
+++ b/harn.toml
@@ -37,6 +37,71 @@ expect_event_count = 1
 
 [[connector_contract.fixtures]]
 provider = "linear"
+name = "issue label update webhook"
+kind = "webhook"
+headers = { "content-type" = "application/json", "linear-signature" = "2769efde0253df7942be7ca5099b3c78226586365570aaecd2b6a8e6356946b6", "linear-delivery" = "delivery-contract-label" }
+body = "{\"action\":\"update\",\"type\":\"IssueLabel\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859200000,\"webhookId\":\"wh_label\",\"actor\":{\"id\":\"usr_1\",\"name\":\"Ada\"},\"data\":{\"id\":\"LBL-1\",\"name\":\"bug\"}}"
+expect_type = "event"
+expect_kind = "linear.issue_label.update"
+expect_dedupe_key = "linear:delivery-contract-label"
+expect_signature_state = "verified"
+expect_payload_contains = { raw = { type = "IssueLabel", action = "update", data = { id = "LBL-1" } } }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "linear"
+name = "project update webhook"
+kind = "webhook"
+headers = { "content-type" = "application/json", "linear-signature" = "6d46939428a0eb36e5239197f91c7ecb7c0f44c495bd638001a75d16bef07014", "linear-delivery" = "delivery-contract-project" }
+body = "{\"action\":\"update\",\"type\":\"Project\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859200000,\"webhookId\":\"wh_project\",\"actor\":{\"id\":\"usr_1\",\"name\":\"Ada\"},\"data\":{\"id\":\"PRJ-1\",\"name\":\"Linear MVP\"}}"
+expect_type = "event"
+expect_kind = "linear.project.update"
+expect_dedupe_key = "linear:delivery-contract-project"
+expect_signature_state = "verified"
+expect_payload_contains = { raw = { type = "Project", action = "update", data = { id = "PRJ-1" } } }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "linear"
+name = "cycle update webhook"
+kind = "webhook"
+headers = { "content-type" = "application/json", "linear-signature" = "b86ef446dd2b685048c3699a522b56c39ca8aafc49c8204c155bc4e04b88f539", "linear-delivery" = "delivery-contract-cycle" }
+body = "{\"action\":\"update\",\"type\":\"Cycle\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859200000,\"webhookId\":\"wh_cycle\",\"actor\":{\"id\":\"usr_1\",\"name\":\"Ada\"},\"data\":{\"id\":\"CYC-1\",\"name\":\"Cycle 1\"}}"
+expect_type = "event"
+expect_kind = "linear.cycle.update"
+expect_dedupe_key = "linear:delivery-contract-cycle"
+expect_signature_state = "verified"
+expect_payload_contains = { raw = { type = "Cycle", action = "update", data = { id = "CYC-1" } } }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "linear"
+name = "customer update webhook"
+kind = "webhook"
+headers = { "content-type" = "application/json", "linear-signature" = "3ccebcafe21717a6c8ffedbe9e6b16220cede6bc2e4dba63691cc8da6596dead", "linear-delivery" = "delivery-contract-customer" }
+body = "{\"action\":\"update\",\"type\":\"Customer\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859200000,\"webhookId\":\"wh_customer\",\"actor\":{\"id\":\"usr_1\",\"name\":\"Ada\"},\"data\":{\"id\":\"CUS-1\",\"name\":\"Acme\"}}"
+expect_type = "event"
+expect_kind = "linear.customer.update"
+expect_dedupe_key = "linear:delivery-contract-customer"
+expect_signature_state = "verified"
+expect_payload_contains = { raw = { type = "Customer", action = "update", data = { id = "CUS-1" } } }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "linear"
+name = "customer request create webhook"
+kind = "webhook"
+headers = { "content-type" = "application/json", "linear-signature" = "937a03553fda1363a9299ff60af9981e53d452caea3683a3afdde9ac8ef7e627", "linear-delivery" = "delivery-contract-customer-request" }
+body = "{\"action\":\"create\",\"type\":\"CustomerRequest\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859200000,\"webhookId\":\"wh_customer_request\",\"actor\":{\"id\":\"usr_1\",\"name\":\"Ada\"},\"data\":{\"id\":\"REQ-1\",\"title\":\"Need this shipped\"}}"
+expect_type = "event"
+expect_kind = "linear.customer_request.create"
+expect_dedupe_key = "linear:delivery-contract-customer-request"
+expect_signature_state = "verified"
+expect_payload_contains = { raw = { type = "CustomerRequest", action = "create", data = { id = "REQ-1" } } }
+expect_event_count = 1
+
+[[connector_contract.fixtures]]
+provider = "linear"
 name = "unsupported action"
 kind = "webhook"
 headers = { "content-type" = "application/json", "linear-signature" = "106ec93bca57d43fc381bacf93e4cd0a9e2aed183dab457d69d0d5669f60238f", "linear-delivery" = "delivery-contract-unsupported" }

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -8,6 +8,30 @@ fn __default_api_base_url() {
   return "https://api.linear.app/graphql"
 }
 
+fn __complexity_warning_threshold() {
+  return 5000
+}
+
+fn __list_issues_query() {
+  return "query HarnLinearListIssues($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean) { issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived) { nodes { id identifier title priority estimate dueDate url createdAt updatedAt state { id name type } team { id key name } assignee { id name email } project { id name } cycle { id name } labels { nodes { id name } } } pageInfo { hasNextPage endCursor } } }"
+}
+
+fn __update_issue_query() {
+  return "mutation HarnLinearUpdateIssue($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success issue { id identifier title priority estimate dueDate url updatedAt state { id name type } assignee { id name email } project { id name } cycle { id name } labels { nodes { id name } } } } }"
+}
+
+fn __create_comment_query() {
+  return "mutation HarnLinearCreateComment($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id body url createdAt user { id name } issue { id identifier title } } } }"
+}
+
+fn __search_issues_query() {
+  return "query HarnLinearSearchIssues($query: String!, $first: Int) { searchIssues(query: $query, first: $first) { nodes { id identifier title url priority state { id name type } team { id key name } } pageInfo { hasNextPage endCursor } } }"
+}
+
+fn __search_issues_term_query() {
+  return "query HarnLinearSearchIssues($term: String!, $first: Int) { searchIssues(term: $term, first: $first) { nodes { id identifier title url priority state { id name type } team { id key name } } pageInfo { hasNextPage endCursor } } }"
+}
+
 fn __header(headers, name) {
   let wanted = lowercase(name)
   for entry in headers ?? {} {
@@ -236,6 +260,100 @@ fn __graphql_errors(payload) {
   return []
 }
 
+fn __graphql_error_codes(errors) {
+  return (errors ?? []).map({ error -> to_string(error?.extensions?.code ?? "") })
+}
+
+fn __has_graphql_error_code(errors, wanted) {
+  for code in __graphql_error_codes(errors) {
+    if lowercase(code) == lowercase(wanted) {
+      return true
+    }
+  }
+  return false
+}
+
+fn __graphql_error_message(status, errors) {
+  if len(errors ?? []) == 0 {
+    return "linear GraphQL request failed with status " + to_string(status)
+  }
+  return "linear GraphQL request failed with status " + to_string(status) + ": "
+    + to_string(errors[0]?.message ?? "Linear GraphQL error")
+}
+
+fn __rate_limited(status, errors) {
+  return status == 429 || (status == 400 && __has_graphql_error_code(errors, "RATELIMITED"))
+}
+
+fn __int_header(headers, name) {
+  let value = __dict_header(headers, name)
+  if value == nil || trim(to_string(value)) == "" {
+    return nil
+  }
+  return to_int(value)
+}
+
+fn __complexity_estimate(query, variables) {
+  if query == nil || trim(query) == "" {
+    return nil
+  }
+  let requested = variables?.first
+  if requested != nil && contains(query, "nodes") {
+    return to_int(requested) + 1
+  }
+  if contains(query, "first: 10") {
+    return 14
+  }
+  if contains(query, "nodes") {
+    return 51
+  }
+  return 2
+}
+
+fn __graphql_meta(headers, query, variables = nil) {
+  let estimate = __complexity_estimate(query, variables ?? {})
+  let observed = __int_header(headers, "x-complexity")
+  let complexity = observed ?? estimate ?? 0
+  return {
+    complexity_estimate: estimate,
+    observed_complexity: observed ?? 0,
+    complexity_warning: complexity >= __complexity_warning_threshold(),
+    rate_limit: {
+    requests_limit: __int_header(headers, "x-ratelimit-requests-limit"),
+    requests_remaining: __int_header(headers, "x-ratelimit-requests-remaining"),
+    requests_reset: __int_header(headers, "x-ratelimit-requests-reset"),
+    complexity_limit: __int_header(headers, "x-ratelimit-complexity-limit"),
+    complexity_remaining: __int_header(headers, "x-ratelimit-complexity-remaining"),
+    complexity_reset: __int_header(headers, "x-ratelimit-complexity-reset"),
+  },
+  }
+}
+
+fn __required_string(args, field) {
+  let value = args?[field]
+  if value == nil || trim(to_string(value)) == "" {
+    throw {message: "linear " + field + " is required", code: "invalid_args", field: field}
+  }
+  return to_string(value)
+}
+
+fn __extract_graphql_field(envelope, field) {
+  let value = envelope?.data?[field]
+  if value == nil {
+    throw {
+      message: "linear connector response missing `" + field + "` GraphQL field",
+      code: "missing_graphql_field",
+      field: field,
+      data: envelope?.data,
+      meta: envelope?.meta,
+    }
+  }
+  if type_of(value) == "dict" {
+    return value + {meta: envelope?.meta}
+  }
+  return {value: value, meta: envelope?.meta}
+}
+
 fn __graphql(args) {
   let query = args?.query
   if query == nil || trim(query) == "" {
@@ -270,20 +388,111 @@ fn __graphql(args) {
   }
   let errors = __graphql_errors(payload)
   if response.status < 200 || response.status >= 300 || len(errors) > 0 {
-    throw {message: "linear GraphQL request failed", status: response.status, errors: errors}
+    let meta = __graphql_meta(response?.headers ?? {}, query, request.variables)
+    let code = if __rate_limited(response.status, errors) {
+      "rate_limited"
+    } else {
+      if len(errors) > 0 {
+        "graphql_error"
+      } else {
+        "http_error"
+      }
+    }
+    throw {
+      message: __graphql_error_message(response.status, errors),
+      code: code,
+      status: response.status,
+      errors: errors,
+      data: payload?.data,
+      meta: meta,
+    }
   }
-  let meta = {
-    observed_complexity: to_int(__dict_header(response?.headers, "x-complexity") ?? 0),
-    rate_limit: {
-    requests_limit: __dict_header(response?.headers, "x-ratelimit-requests-limit"),
-    requests_remaining: __dict_header(response?.headers, "x-ratelimit-requests-remaining"),
-    requests_reset: __dict_header(response?.headers, "x-ratelimit-requests-reset"),
-    complexity_limit: __dict_header(response?.headers, "x-ratelimit-complexity-limit"),
-    complexity_remaining: __dict_header(response?.headers, "x-ratelimit-complexity-remaining"),
-    complexity_reset: __dict_header(response?.headers, "x-ratelimit-complexity-reset"),
-  },
-  }
+  let meta = __graphql_meta(response?.headers ?? {}, query, request.variables)
   return payload + {meta: meta}
+}
+
+fn __list_issues(args) {
+  return __extract_graphql_field(
+    __graphql(
+    args ?? {}
+    + {
+    query: __list_issues_query(),
+    variables: {
+    filter: args?.filter,
+    first: args?.first,
+    after: args?.after,
+    includeArchived: args?.include_archived ?? args?.includeArchived ?? false,
+  },
+    operation_name: "HarnLinearListIssues",
+  },
+  ),
+    "issues",
+  )
+}
+
+fn __update_issue(args) {
+  return __extract_graphql_field(
+    __graphql(
+    args ?? {}
+    + {
+    query: __update_issue_query(),
+    variables: {id: __required_string(args, "id"), input: args?.changes ?? {}},
+    operation_name: "HarnLinearUpdateIssue",
+  },
+  ),
+    "issueUpdate",
+  )
+}
+
+fn __create_comment(args) {
+  return __extract_graphql_field(
+    __graphql(
+    args ?? {}
+    + {
+    query: __create_comment_query(),
+    variables: {input: {issueId: __required_string(args, "issue_id"), body: __required_string(args, "body")}},
+    operation_name: "HarnLinearCreateComment",
+  },
+  ),
+    "commentCreate",
+  )
+}
+
+fn __search(args) {
+  let first = args?.first ?? 10
+  let query = __required_string(args, "query")
+  let primary = try {
+    __extract_graphql_field(
+    __graphql(
+    args ?? {}
+    + {
+    query: __search_issues_query(),
+    variables: {query: query, first: first},
+    operation_name: "HarnLinearSearchIssues",
+  },
+  ),
+    "searchIssues",
+  )
+  }
+  if is_ok(primary) {
+    return unwrap(primary)
+  }
+  let err = unwrap_err(primary)
+  if !contains(to_string(err?.message ?? ""), "Unknown argument")
+    && !__has_graphql_error_code(err?.errors, "GRAPHQL_VALIDATION_FAILED") {
+    throw err
+  }
+  return __extract_graphql_field(
+    __graphql(
+    args ?? {}
+    + {
+    query: __search_issues_term_query(),
+    variables: {term: query, first: first},
+    operation_name: "HarnLinearSearchIssues",
+  },
+  ),
+    "searchIssues",
+  )
 }
 
 /** Return the Harn provider id for this connector. */
@@ -355,49 +564,16 @@ pub fn call(method, args) {
     return __graphql(args ?? {})
   }
   if method == "list_issues" {
-    return __graphql(
-      args ?? {}
-      + {
-      query: "query HarnLinearListIssues($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean) { issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived) { nodes { id identifier title priority state { id name type } assignee { id name email } team { id key name } } pageInfo { hasNextPage endCursor } } }",
-      variables: {
-      filter: args?.filter,
-      first: args?.first,
-      after: args?.after,
-      includeArchived: args?.include_archived ?? args?.includeArchived ?? false,
-    },
-      operation_name: "HarnLinearListIssues",
-    },
-    ).data.issues
+    return __list_issues(args ?? {})
   }
   if method == "update_issue" {
-    return __graphql(
-      args ?? {}
-      + {
-      query: "mutation HarnLinearUpdateIssue($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success issue { id identifier title priority state { id name type } } } }",
-      variables: {id: args?.id, input: args?.changes ?? {}},
-      operation_name: "HarnLinearUpdateIssue",
-    },
-    ).data.issueUpdate
+    return __update_issue(args ?? {})
   }
   if method == "create_comment" {
-    return __graphql(
-      args ?? {}
-      + {
-      query: "mutation HarnLinearCreateComment($issueId: String!, $body: String!) { commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id body issue { id identifier } } } }",
-      variables: {issueId: args?.issue_id ?? args?.issueId, body: args?.body},
-      operation_name: "HarnLinearCreateComment",
-    },
-    ).data.commentCreate
+    return __create_comment(args ?? {} + {issue_id: args?.issue_id ?? args?.issueId})
   }
   if method == "search" {
-    return __graphql(
-      args ?? {}
-      + {
-      query: "query HarnLinearSearch($query: String!, $first: Int) { issueSearch(query: $query, first: $first) { nodes { id identifier title priority } pageInfo { hasNextPage endCursor } } }",
-      variables: {query: args?.query, first: args?.first ?? 10},
-      operation_name: "HarnLinearSearch",
-    },
-    ).data.issueSearch
+    return __search(args ?? {})
   }
   throw "method_not_found:" + method
 }

--- a/tests/fixtures/normalized/linear_variants.json
+++ b/tests/fixtures/normalized/linear_variants.json
@@ -1,0 +1,11 @@
+{
+  "variants": [
+    {"fixture": "issue_update", "kind": "linear.issue.update", "data_id": "ISS-1"},
+    {"fixture": "comment_create", "kind": "linear.comment.create", "data_id": "COM-1"},
+    {"fixture": "issue_label_update", "kind": "linear.issue_label.update", "data_id": "LBL-1"},
+    {"fixture": "project_update", "kind": "linear.project.update", "data_id": "PRJ-1"},
+    {"fixture": "cycle_update", "kind": "linear.cycle.update", "data_id": "CYC-1"},
+    {"fixture": "customer_update", "kind": "linear.customer.update", "data_id": "CUS-1"},
+    {"fixture": "customer_request_create", "kind": "linear.customer_request.create", "data_id": "REQ-1"}
+  ]
+}

--- a/tests/fixtures/webhooks/customer_request_create.json
+++ b/tests/fixtures/webhooks/customer_request_create.json
@@ -1,0 +1,1 @@
+{"action":"create","type":"CustomerRequest","organizationId":"org_123","webhookTimestamp":1776859200000,"webhookId":"wh_customer_request","actor":{"id":"usr_1","name":"Ada"},"data":{"id":"REQ-1","title":"Need this shipped"}}

--- a/tests/fixtures/webhooks/customer_update.json
+++ b/tests/fixtures/webhooks/customer_update.json
@@ -1,0 +1,1 @@
+{"action":"update","type":"Customer","organizationId":"org_123","webhookTimestamp":1776859200000,"webhookId":"wh_customer","actor":{"id":"usr_1","name":"Ada"},"data":{"id":"CUS-1","name":"Acme"}}

--- a/tests/fixtures/webhooks/cycle_update.json
+++ b/tests/fixtures/webhooks/cycle_update.json
@@ -1,0 +1,1 @@
+{"action":"update","type":"Cycle","organizationId":"org_123","webhookTimestamp":1776859200000,"webhookId":"wh_cycle","actor":{"id":"usr_1","name":"Ada"},"data":{"id":"CYC-1","name":"Cycle 1"}}

--- a/tests/fixtures/webhooks/issue_label_update.json
+++ b/tests/fixtures/webhooks/issue_label_update.json
@@ -1,0 +1,1 @@
+{"action":"update","type":"IssueLabel","organizationId":"org_123","webhookTimestamp":1776859200000,"webhookId":"wh_label","actor":{"id":"usr_1","name":"Ada"},"data":{"id":"LBL-1","name":"bug"}}

--- a/tests/fixtures/webhooks/project_update.json
+++ b/tests/fixtures/webhooks/project_update.json
@@ -1,0 +1,1 @@
+{"action":"update","type":"Project","organizationId":"org_123","webhookTimestamp":1776859200000,"webhookId":"wh_project","actor":{"id":"usr_1","name":"Ada"},"data":{"id":"PRJ-1","name":"Linear MVP"}}

--- a/tests/graphql_smoke.harn
+++ b/tests/graphql_smoke.harn
@@ -1,15 +1,54 @@
 import { call } from "../src/lib.harn"
 
 pipeline test(task) {
+  http_mock_clear()
   http_mock(
     "POST",
     "https://linear.test/graphql",
     {
     responses: [
-    {status: 200, headers: {["x-complexity"]: "12"}, body: "{\"data\":{\"viewer\":{\"id\":\"usr_1\"}}}"},
+    {
+    status: 200,
+    headers: {
+    ["x-complexity"]: "12",
+    ["x-ratelimit-requests-limit"]: "1500",
+    ["x-ratelimit-requests-remaining"]: "1499",
+  },
+    body: "{\"data\":{\"viewer\":{\"id\":\"usr_1\"}}}",
+  },
     {
     status: 200,
     body: "{\"errors\":[{\"message\":\"Invalid token\",\"path\":[\"viewer\"],\"extensions\":{\"code\":\"AUTHENTICATION_ERROR\"}}]}",
+  },
+    {
+    status: 200,
+    headers: {["x-complexity"]: "48"},
+    body: "{\"data\":{\"issues\":{\"nodes\":[{\"id\":\"iss_1\",\"identifier\":\"ENG-1\",\"title\":\"Connector issue\"}],\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"cursor-1\"}}}}",
+  },
+    {
+    status: 200,
+    body: "{\"data\":{\"issueUpdate\":{\"success\":true,\"issue\":{\"id\":\"iss_1\",\"identifier\":\"ENG-1\",\"title\":\"Updated\"}}}}",
+  },
+    {
+    status: 200,
+    body: "{\"data\":{\"commentCreate\":{\"success\":true,\"comment\":{\"id\":\"com_1\",\"body\":\"Looks good\",\"issue\":{\"id\":\"iss_1\",\"identifier\":\"ENG-1\"}}}}}",
+  },
+    {
+    status: 200,
+    body: "{\"errors\":[{\"message\":\"Unknown argument \\\"query\\\" on field \\\"searchIssues\\\"\",\"extensions\":{\"code\":\"GRAPHQL_VALIDATION_FAILED\"}}]}",
+  },
+    {
+    status: 200,
+    body: "{\"data\":{\"searchIssues\":{\"nodes\":[{\"id\":\"iss_2\",\"identifier\":\"ENG-2\",\"title\":\"Search hit\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}",
+  },
+    {
+    status: 200,
+    body: "{\"data\":{\"viewer\":{\"id\":\"usr_partial\"}},\"errors\":[{\"message\":\"field failed\",\"path\":[\"viewer\",\"name\"],\"extensions\":{\"code\":\"INTERNAL_ERROR\"}}]}",
+  },
+    {
+    status: 400,
+    headers: {["x-ratelimit-requests-reset"]: "1776859300"},
+    body: "{\"errors\":[{\"message\":\"rate limit exceeded\",\"extensions\":{\"code\":\"RATELIMITED\"}}]}",
   },
   ],
   },
@@ -24,6 +63,7 @@ pipeline test(task) {
   )
   assert_eq(ok.data.viewer.id, "usr_1")
   assert_eq(ok.meta.observed_complexity, 12)
+  assert_eq(ok.meta.rate_limit.requests_limit, 1500)
   let calls = http_mock_calls()
   assert_eq(calls[0].headers.Authorization, "lin_api_key")
   let sent = json_parse(calls[0].body)
@@ -40,8 +80,88 @@ pipeline test(task) {
   }
   assert(is_err(failed))
   let error = unwrap_err(failed)
+  assert_eq(error.code, "graphql_error")
   assert_eq(error.errors[0].message, "Invalid token")
   assert_eq(error.errors[0].extensions.code, "AUTHENTICATION_ERROR")
+  let issues = call(
+    "list_issues",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    filter: {priority: {lte: 2}},
+    first: 10,
+    after: "cursor-0",
+  },
+  )
+  assert_eq(issues.nodes[0].identifier, "ENG-1")
+  assert_eq(issues.pageInfo.hasNextPage, true)
+  assert_eq(issues.meta.observed_complexity, 48)
+  let updated = call(
+    "update_issue",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    id: "iss_1",
+    changes: {title: "Updated"},
+  },
+  )
+  assert_eq(updated.success, true)
+  assert_eq(updated.issue.title, "Updated")
+  let comment = call(
+    "create_comment",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    issue_id: "iss_1",
+    body: "Looks good",
+  },
+  )
+  assert_eq(comment.comment.id, "com_1")
+  let search = call(
+    "search",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    query: "connector",
+    first: 5,
+  },
+  )
+  assert_eq(search.nodes[0].identifier, "ENG-2")
+  let partial = try {
+    call(
+    "graphql",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    query: "query Viewer { viewer { id name } }",
+  },
+  )
+  }
+  assert(is_err(partial))
+  let partial_error = unwrap_err(partial)
+  assert_eq(partial_error.code, "graphql_error")
+  assert_eq(partial_error.data.viewer.id, "usr_partial")
+  let limited = try {
+    call(
+    "graphql",
+    {
+    api_base_url: "https://linear.test/graphql",
+    access_token: "oauth-token",
+    query: "query Viewer { viewer { id } }",
+  },
+  )
+  }
+  assert(is_err(limited))
+  let limited_error = unwrap_err(limited)
+  assert_eq(limited_error.code, "rate_limited")
+  assert_eq(limited_error.status, 400)
+  assert_eq(limited_error.meta.rate_limit.requests_reset, 1776859300)
   let all_calls = http_mock_calls()
   assert_eq(all_calls[1].headers.Authorization, "Bearer oauth-token")
+  assert(contains(json_parse(all_calls[2].body).query, "issues("))
+  assert_eq(json_parse(all_calls[2].body).operationName, "HarnLinearListIssues")
+  assert(contains(json_parse(all_calls[3].body).query, "issueUpdate"))
+  assert(contains(json_parse(all_calls[4].body).query, "commentCreate"))
+  assert(contains(json_parse(all_calls[5].body).query, "searchIssues"))
+  assert_eq(json_parse(all_calls[6].body).variables.term, "connector")
 }

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -38,6 +38,15 @@ pipeline test(task) {
   let comment = normalize_inbound(raw(comment_body, "test-secret"))
   assert_eq(comment.event.kind, "linear.comment.create")
   assert_eq(comment.event.payload.data.id, "COM-1")
+  let variants = json_parse(read_file("tests/fixtures/normalized/linear_variants.json")).variants
+  for variant in variants {
+    let body = trim(read_file("tests/fixtures/webhooks/" + variant.fixture + ".json"))
+    let normalized = normalize_inbound(raw(body, "test-secret"))
+    assert_eq(normalized.type, "event")
+    assert_eq(normalized.event.kind, variant.kind)
+    assert_eq(normalized.event.signature_status.state, "verified")
+    assert_eq(normalized.event.payload.data.id, variant.data_id)
+  }
   let edge_body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859140000,\"webhookId\":\"wh_edge\",\"data\":{\"id\":\"ISS-EDGE\"}}"
   assert_eq(normalize_inbound(raw(edge_body, "test-secret")).type, "event")
   let stale_body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859139000,\"webhookId\":\"wh_stale\",\"data\":{\"id\":\"ISS-STALE\"}}"


### PR DESCRIPTION
## Summary
- add a local hand-written typed GraphQL helper layer for Linear MVP outbound methods, with shared query documents, argument validation, pagination/meta propagation, partial-data GraphQL errors, and `RATELIMITED` classification
- expand Linear compatibility coverage to all MVP resource variants from the Rust-side connector list and assert contract-level payload/dedupe/signature expectations
- document secrets, OAuth/API-key auth, scopes, supported events, outbound methods, pagination, rate limits, local workflow, and the no-external-SDK decision

## Verification
- `harn --version` -> `harn 0.7.42`
- `harn check src`
- `harn lint src`
- `harn fmt --check src tests`
- `for test in tests/*.harn; do harn run "$test"; done`
- `harn connector check .`
- clean consumer smoke with `harn add /Users/ksinder/.codex/worktrees/4b47/harn-linear-connector@HEAD` and `harn check smoke.harn`
- temp-root pinned CLI run using `.harn-version` (`harn 0.7.39`) with check / lint / fmt / smoke tests / connector check

Addresses #1, #4, and #6.
