### PR TITLE
Complete Linear MVP readiness and docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ webhook signatures, enforces Linear's 60-second replay window, normalizes
 Linear event payloads to the canonical `TriggerEvent` shape, and dispatches
 outbound GraphQL queries.
 
-> **Status: pre-alpha** — actively developed in tandem with
-> [burin-labs/harn](https://github.com/burin-labs/harn). See the
-> [Pure-Harn Connectors Pivot epic #350](https://github.com/burin-labs/harn/issues/350).
+> **Status: pre-alpha** — this repo is a first-party connector package for
+> Harn `0.7.42` or newer. CI installs the pinned CLI version from
+> `.harn-version`.
 
 This is an **inbound + outbound** connector implementing Harn Connector
-Contract v1. It requires a Harn version that includes
-[harn#464](https://github.com/burin-labs/harn/issues/464) and
-[harn#468](https://github.com/burin-labs/harn/issues/468).
+Contract v1. The canonical contract docs live in the Harn repo:
+
+- [Connector authoring](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md)
+- [Connector architecture](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/architecture.md)
 
 Linear has no OpenAPI spec: its public API is GraphQL. For v0.1 this package
 keeps a small hand-written GraphQL helper layer in `src/lib.harn` instead of
@@ -66,8 +67,9 @@ trigger triage on linear {
 
 Inbound webhooks require the Linear webhook signing secret. The connector
 checks `raw.signing_secret`, `raw.metadata.signing_secret`,
-`binding.config.signing_secret`, or `binding.config.secrets.signing_secret`;
-otherwise it reads `linear/signing-secret` through `secret_get`.
+`binding.config.signing_secret`, `binding.config.secrets.signing_secret`, or
+managed-ingress secret aliases in `raw.metadata.secret_ids`; otherwise it reads
+`linear/signing-secret` through `secret_get`.
 
 Outbound calls require one of:
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -50,7 +50,7 @@ fn __binding_for_raw(raw) {
   let binding_id = raw?.binding_id ?? raw?.metadata?.binding_id
   if binding_id != nil {
     for binding in connector_state.bindings {
-      if binding.id == binding_id {
+      if binding.id == binding_id || binding.binding_id == binding_id {
         return binding
       }
     }
@@ -76,7 +76,18 @@ fn __secret_value(value, fallback_id) {
   return raw
 }
 
+fn __metadata_secret_alias(raw, name) {
+  if raw?.metadata?.secret_ids?[name] != nil {
+    return secret_get("linear/" + name)
+  }
+  return nil
+}
+
 fn __signing_secret(raw) {
+  let metadata_alias = __metadata_secret_alias(raw, "signing_secret")
+  if metadata_alias != nil {
+    return metadata_alias
+  }
   let config = __binding_config(raw)
   return __secret_value(
     raw?.signing_secret ?? raw?.metadata?.signing_secret ?? config?.signing_secret
@@ -290,7 +301,13 @@ fn __int_header(headers, name) {
   if value == nil || trim(to_string(value)) == "" {
     return nil
   }
-  return to_int(value)
+  let parsed = try {
+    to_int(value)
+  }
+  if is_ok(parsed) {
+    return unwrap(parsed)
+  }
+  return nil
 }
 
 fn __complexity_estimate(query, variables) {

--- a/tests/graphql_smoke.harn
+++ b/tests/graphql_smoke.harn
@@ -1,5 +1,15 @@
 import { call } from "../src/lib.harn"
 
+fn recorded_header(headers, name) {
+  let wanted = lowercase(name)
+  for entry in headers ?? {} {
+    if lowercase(entry.key) == wanted {
+      return entry.value
+    }
+  }
+  return nil
+}
+
 pipeline test(task) {
   http_mock_clear()
   http_mock(
@@ -50,6 +60,11 @@ pipeline test(task) {
           headers: {["x-ratelimit-requests-reset"]: "1776859300"},
           body: "{\"errors\":[{\"message\":\"rate limit exceeded\",\"extensions\":{\"code\":\"RATELIMITED\"}}]}",
         },
+        {
+          status: 200,
+          headers: {["x-complexity"]: "not-a-number"},
+          body: "{\"data\":{\"viewer\":{\"id\":\"usr_3\"}}}",
+        },
       ],
     },
   )
@@ -65,7 +80,8 @@ pipeline test(task) {
   assert_eq(ok.meta.observed_complexity, 12)
   assert_eq(ok.meta.rate_limit.requests_limit, 1500)
   let calls = http_mock_calls()
-  assert_eq(calls[0].headers.authorization, "[redacted]")
+  let first_auth = recorded_header(calls[0].headers, "authorization")
+  assert(first_auth == "lin_api_key" || first_auth == "[redacted]")
   let sent = json_parse(calls[0].body)
   assert_eq(sent["query"], "query Viewer { viewer { id } }")
   let failed = try {
@@ -157,11 +173,22 @@ pipeline test(task) {
   assert_eq(limited_error.status, 400)
   assert_eq(limited_error.meta.rate_limit.requests_reset, 1776859300)
   let all_calls = http_mock_calls()
-  assert_eq(all_calls[1].headers.authorization, "[redacted]")
+  let oauth_auth = recorded_header(all_calls[1].headers, "authorization")
+  assert(oauth_auth == "Bearer oauth-token" || oauth_auth == "[redacted]")
   assert(contains(json_parse(all_calls[2].body).query, "issues("))
   assert_eq(json_parse(all_calls[2].body).operationName, "HarnLinearListIssues")
   assert(contains(json_parse(all_calls[3].body).query, "issueUpdate"))
   assert(contains(json_parse(all_calls[4].body).query, "commentCreate"))
   assert(contains(json_parse(all_calls[5].body).query, "searchIssues"))
   assert_eq(json_parse(all_calls[6].body).variables.term, "connector")
+  let malformed_header = call(
+    "graphql",
+    {
+    api_base_url: "https://linear.test/graphql",
+    api_key: "lin_api_key",
+    query: "query Viewer { viewer { id } }",
+  },
+  )
+  assert_eq(malformed_header.data.viewer.id, "usr_3")
+  assert_eq(malformed_header.meta.observed_complexity, 0)
 }


### PR DESCRIPTION
## Summary
- follow up on the merged MVP/readiness work from #11 with the remaining docs refresh for closed Harn substrate blockers
- document current Harn `0.7.42` requirements, canonical connector docs, managed-ingress secret aliases, auth/scopes, pagination, errors, rate limits, and the local GraphQL helper decision
- fix managed-ingress signing-secret alias resolution discovered during self-review harn-cloud smoke
- harden GraphQL metadata parsing so malformed rate-limit/complexity headers do not fail otherwise-successful responses
- make outbound smoke assertions compatible with current Authorization header redaction in Harn mocks

Closes #1.
Closes #6.
Closes #12.
Addresses #2.

## Self-review notes
- Read the final diff with a fresh pass for auth/secret handling, GraphQL error semantics, malformed response metadata, and harn-cloud managed-ingress loading.
- Found and fixed a managed-ingress integration gap: harn-cloud passes secret aliases through `raw.metadata.secret_ids`, so the connector now resolves the signing secret through the `linear/signing_secret` alias path when present.
- Found and fixed a robustness gap: malformed rate-limit or complexity headers no longer make successful GraphQL calls fail while building metadata.

## Verification
- `/tmp/harn-cli-0.7.42/bin/harn --version` -> `harn 0.7.42`
- `/tmp/harn-cli-0.7.42/bin/harn fmt --check src tests`
- `/tmp/harn-cli-0.7.42/bin/harn check src/lib.harn`
- `/tmp/harn-cli-0.7.42/bin/harn lint src/lib.harn`
- `for test in tests/*.harn; do /tmp/harn-cli-0.7.42/bin/harn run "$test" || exit 1; done`
- `/tmp/harn-cli-0.7.42/bin/harn connector check .`
- clean temp consumer package: `/tmp/harn-cli-0.7.42/bin/harn add /Users/ksinder/.codex/worktrees/3e66/harn-linear-connector` + `/tmp/harn-cli-0.7.42/bin/harn check smoke.harn`
- temporary harn-cloud managed-ingress smoke against this local package path: `CARGO_TARGET_DIR=/tmp/harn-cloud-target-linear-smoke cargo test -p harn-cloud-gateway linear_harn_connector_local_package_loads_in_managed_ingress --test gateway -- --nocapture`
