### PR TITLE
Add CI status rollup gate to satisfy org rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,17 @@ jobs:
         run: |
           set -euo pipefail
           harn connector test "$GITHUB_WORKSPACE" --provider linear
+
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [harn]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
Adds a rollup job named `CI status` to satisfy the `burin-labs/main protection` org ruleset which requires that exact context name. Other burin-labs repos already use this pattern; this brings harn-linear-connector into line.