### PR TITLE
Polish Linear connector for latest Harn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Linear event payloads to the canonical `TriggerEvent` shape, and dispatches
 outbound GraphQL queries.
 
 > **Status: pre-alpha** — this repo is a first-party connector package for
-> Harn `0.8.26` or newer. CI installs the pinned CLI version from
+> Harn `0.8.32` or newer. CI installs the pinned CLI version from
 > `.harn-version`.
 
 This is an **inbound + outbound** connector implementing Harn Connector
@@ -16,10 +16,10 @@ Contract v1. The canonical contract docs live in the Harn repo:
 - [Connector architecture](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/architecture.md)
 
 Linear has no OpenAPI spec — its public API is GraphQL. Outbound calls use
-Harn's `std/graphql` operation/envelope helpers so query documents, errors,
-rate-limit metadata, and cursor pagination are handled the same way as other
-GraphQL-first connector packages. A larger fully generated `linear-sdk-harn`
-can build on the same substrate later.
+Harn's `std/graphql` operation/envelope helpers and shared connector HTTP
+policy so query documents, errors, rate-limit metadata, and cursor pagination
+are handled the same way as other GraphQL-first connector packages. A larger
+fully generated `linear-sdk-harn` can build on the same substrate later.
 
 ## Install
 
@@ -67,9 +67,10 @@ trigger triage on linear {
 
 Inbound webhooks require the Linear webhook signing secret. The connector
 checks `raw.signing_secret`, `raw.metadata.signing_secret`,
-`binding.config.signing_secret`, `binding.config.secrets.signing_secret`, or
-managed-ingress secret aliases in `raw.metadata.secret_ids`; otherwise it reads
-`linear/webhook-secret` through `secret_get`.
+`binding.config.signing_secret`, `binding.config.secrets.signing_secret`,
+`binding.config.secret_ids.signing_secret`, or managed-ingress secret aliases
+in `raw.metadata.secret_ids` or `raw.metadata.config.secret_ids`; otherwise it
+reads `linear/webhook-secret` through `secret_get`.
 
 Outbound calls require one of:
 

--- a/harn.toml
+++ b/harn.toml
@@ -15,8 +15,8 @@ capabilities = ["webhook", "oauth", "rate_limit", "pagination", "graphql"]
 
 [providers.setup]
 auth_type = "oauth2"
-flow = "oauth2"
-required_scopes = ["read"]
+flow = "browser"
+required_scopes = ["read", "write"]
 required_secrets = ["linear/api-token", "linear/webhook-secret"]
 setup_command = ["harn", "connect", "linear"]
 validation_command = ["harn", "connect", "status", "--connector", "linear", "--json"]

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -1,9 +1,15 @@
 import {
+  connector_http_header,
+  connector_http_json,
+  verify_hmac_signature,
+} from "std/connectors/shared"
+import {
   graphql_auth_headers,
   graphql_extract,
   graphql_normalize_response,
   graphql_operation,
   graphql_page_info,
+  graphql_request_body,
 } from "std/graphql"
 import { merge } from "std/json"
 
@@ -42,17 +48,7 @@ fn __search_issues_term_query() {
 }
 
 fn __header(headers, name) {
-  let wanted = lowercase(name)
-  for entry in headers ?? {} {
-    if lowercase(entry.key) == wanted {
-      return entry.value
-    }
-  }
-  return nil
-}
-
-fn __dict_header(headers, name) {
-  return __header(headers ?? {}, name)
+  return connector_http_header(headers ?? {}, name)
 }
 
 fn __binding_for_raw(raw) {
@@ -90,16 +86,42 @@ fn __auth_token(literal, secret_ref, fallback_id) {
   return __secret_ref(secret_ref, fallback_id)
 }
 
-fn __metadata_secret_alias(raw, name) {
-  if raw?.metadata?.secret_ids?[name] != nil {
-    let value = try {
-      secret_get("linear/" + name)
-    }
-    if is_ok(value) {
-      return unwrap(value)
-    }
+fn __secret_id_candidate(value, fallback_name) {
+  let raw = trim(to_string(value ?? ""))
+  if raw == "" {
+    return nil
+  }
+  if contains(raw, "/") {
+    return raw
+  }
+  return "linear/" + fallback_name
+}
+
+fn __secret_get_optional(secret_id) {
+  if secret_id == nil {
+    return nil
+  }
+  let value = try {
+    secret_get(secret_id)
+  }
+  if is_ok(value) {
+    return unwrap(value)
   }
   return nil
+}
+
+fn __secret_ref_with_alias(value, fallback_name, fallback_id) {
+  let candidate = __secret_id_candidate(value, fallback_name)
+  if candidate != nil {
+    return secret_get(candidate)
+  }
+  return secret_get(fallback_id)
+}
+
+fn __metadata_secret_alias(raw, name) {
+  let alias = raw?.metadata?.secret_ids?[name] ?? raw?.metadata?.config?.secret_ids?[name]
+    ?? raw?.config?.secret_ids?[name]
+  return __secret_get_optional(__secret_id_candidate(alias, name))
 }
 
 fn __signing_secret(raw) {
@@ -112,7 +134,11 @@ fn __signing_secret(raw) {
   if literal != nil && trim(to_string(literal)) != "" {
     return to_string(literal)
   }
-  return __secret_ref(config?.secrets?.signing_secret, __default_signing_secret_id())
+  return __secret_ref_with_alias(
+    config?.secrets?.signing_secret ?? config?.secret_ids?.signing_secret,
+    "signing_secret",
+    __default_signing_secret_id(),
+  )
 }
 
 fn __received_at_seconds(raw) {
@@ -201,6 +227,13 @@ fn __verify(raw, body) {
     return __reject(400, "missing_webhook_timestamp", "Linear webhookTimestamp is required")
   }
   let timestamp_ms = __unix_ms(body.webhookTimestamp)
+  if timestamp_ms == nil {
+    return __reject(
+      400,
+      "invalid_webhook_timestamp",
+      "Linear webhookTimestamp must be a Unix millisecond timestamp",
+    )
+  }
   let received_ms = to_int(__received_at_seconds(raw) * 1000)
   let age_ms = if received_ms >= timestamp_ms {
     received_ms - timestamp_ms
@@ -218,8 +251,12 @@ fn __verify(raw, body) {
   if signature == nil || trim(signature) == "" {
     return __reject(401, "missing_signature", "linear-signature header is required")
   }
-  let expected = hmac_sha256(__signing_secret(raw), raw.body_text ?? json_stringify(body))
-  if !constant_time_eq(expected, trim(signature)) {
+  if !verify_hmac_signature(
+    raw.body_text ?? json_stringify(body),
+    signature,
+    __signing_secret(raw),
+    "sha256",
+  ) {
     return __reject(401, "invalid_signature", "linear-signature did not match the raw request body")
   }
   return nil
@@ -285,20 +322,6 @@ fn __auth_config(args) {
   }
 }
 
-fn __graphql_errors(payload) {
-  if type_of(payload?.errors) == "list" && len(payload.errors) > 0 {
-    return payload.errors
-      .map(
-      { error -> {
-        message: error?.message ?? "Linear GraphQL error",
-        path: error?.path,
-        extensions: error?.extensions ?? {},
-      } },
-    )
-  }
-  return []
-}
-
 fn __graphql_error_codes(errors) {
   return (errors ?? []).map({ error -> to_string(error?.extensions?.code ?? "") })
 }
@@ -325,7 +348,7 @@ fn __rate_limited(status, errors) {
 }
 
 fn __int_header(headers, name) {
-  let value = __dict_header(headers, name)
+  let value = connector_http_header(headers ?? {}, name)
   if value == nil || trim(to_string(value)) == "" {
     return nil
   }
@@ -374,6 +397,21 @@ fn __graphql_meta(headers, query, variables = nil) {
   }
 }
 
+fn __meta_with_complexity(meta, header_meta) {
+  return merge(
+    meta ?? {},
+    {
+      observed_complexity: header_meta.observed_complexity,
+      complexity_estimate: header_meta.complexity_estimate,
+      complexity_warning: header_meta.complexity_warning,
+    },
+  )
+}
+
+fn __missing_http_response(response) {
+  return !(response?.ok ?? false) && response?.status == nil && response?.body == nil
+}
+
 fn __required_string(args, field) {
   let value = args?[field]
   if value == nil || trim(to_string(value)) == "" {
@@ -393,28 +431,36 @@ fn __graphql(args) {
   } else {
     auth.token
   }
-  let request = {
-    query: query,
-    variables: args?.variables ?? {},
-    operationName: args?.operation_name ?? args?.operationName,
-  }
-  let response = http_post(
+  let request = graphql_request_body(
+    query,
+    args?.variables ?? {},
+    {operation_name: args?.operation_name ?? args?.operationName},
+  )
+  let response = connector_http_json(
+    "POST",
     args?.api_base_url ?? __default_api_base_url(),
-    json_stringify(request),
     {
+      provider: "linear",
+      operation: request.operationName ?? "graphql",
       headers: graphql_auth_headers({authorization: authorization}, {"User-Agent": "harn-linear-connector"}),
+      body: json_stringify(request),
     },
   )
-  let envelope = graphql_normalize_response(response, {operation_name: request.operationName})
   let header_meta = __graphql_meta(response?.headers ?? {}, query, request.variables)
-  let merged_meta = merge(
-    envelope.meta,
-    {
-      observed_complexity: header_meta.observed_complexity,
-      complexity_estimate: header_meta.complexity_estimate,
-      complexity_warning: header_meta.complexity_warning,
-    },
-  )
+  if __missing_http_response(response) {
+    throw {
+      message: to_string(response?.error?.message ?? "linear GraphQL request failed before receiving a response"),
+      code: "http_error",
+      status: response?.status,
+      category: response?.category ?? response?.error?.category,
+      retryable: response?.retryable ?? response?.error?.retryable,
+      errors: [],
+      data: nil,
+      meta: __meta_with_complexity({}, header_meta),
+    }
+  }
+  let envelope = graphql_normalize_response(response, {operation_name: request.operationName})
+  let merged_meta = __meta_with_complexity(envelope.meta, header_meta)
   if !envelope.ok {
     let errors = envelope.errors
     let code = if __rate_limited(envelope.meta.status, errors) {

--- a/tests/graphql_smoke.harn
+++ b/tests/graphql_smoke.harn
@@ -224,4 +224,14 @@ pipeline test(task) {
   let slash_token_calls = http_mock_calls()
   let slash_token_auth = recorded_header(slash_token_calls[len(slash_token_calls) - 1].headers, "authorization")
   assert(slash_token_auth == "Bearer oauth/with/slash" || slash_token_auth == "[redacted]")
+  let invalid_url = try {
+    call(
+      "graphql",
+      {api_base_url: "not-a-url", api_key: "lin_api_key", query: "query Viewer { viewer { id } }"},
+    )
+  }
+  assert(is_err(invalid_url))
+  let invalid_url_error = unwrap_err(invalid_url)
+  assert_eq(invalid_url_error.code, "http_error")
+  assert_eq(invalid_url_error.category, "invalid_request")
 }

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -40,14 +40,22 @@ fn cloud_raw(body, secret, received_at = "2026-04-22T12:00:00Z") {
   }
 }
 
+fn fixture_text(path) {
+  return trim(harness.fs.read_text(path))
+}
+
+fn fixture_json(path) {
+  return json_parse(harness.fs.read_text(path))
+}
+
 pipeline test(task) {
   activate([{id: "linear.test", kind: "webhook", config: {signing_secret: "test-secret"}}])
   assert_eq(provider_id(), "linear")
   assert_eq(kinds(), ["webhook"])
   assert_eq(payload_schema().harn_schema_name, "LinearEventPayload")
-  let issue_body = trim(read_file("tests/fixtures/webhooks/issue_update.json"))
+  let issue_body = fixture_text("tests/fixtures/webhooks/issue_update.json")
   let issue = normalize_inbound(raw(issue_body, "test-secret"))
-  let snapshot = json_parse(read_file("tests/fixtures/normalized/issue_update.json"))
+  let snapshot = fixture_json("tests/fixtures/normalized/issue_update.json")
   assert_eq(issue.type, "event")
   assert_eq(issue.event.kind, snapshot.event.kind)
   assert_eq(issue.event.dedupe_key, snapshot.event.dedupe_key)
@@ -60,14 +68,14 @@ pipeline test(task) {
   assert_eq(cloud.event.kind, "linear.issue.update")
   assert_eq(cloud.event.dedupe_key, "linear:delivery-cloud")
   assert_eq(cloud.event.tenant_id, "tenant-acme")
-  let comment_body = trim(read_file("tests/fixtures/webhooks/comment_create.json"))
+  let comment_body = fixture_text("tests/fixtures/webhooks/comment_create.json")
   let comment = normalize_inbound(raw(comment_body, "test-secret"))
   assert_eq(comment.event.kind, "linear.comment.create")
   assert_eq(comment.event.payload.data.id, "COM-1")
-  let variant_snapshot = json_parse(read_file("tests/fixtures/normalized/linear_variants.json"))
+  let variant_snapshot = fixture_json("tests/fixtures/normalized/linear_variants.json")
   let variants = variant_snapshot.variants
   for variant in variants {
-    let body = trim(read_file("tests/fixtures/webhooks/" + variant.fixture + ".json"))
+    let body = fixture_text("tests/fixtures/webhooks/" + variant.fixture + ".json")
     let normalized = normalize_inbound(raw(body, "test-secret"))
     assert_eq(normalized.type, "event")
     assert_eq(normalized.event.kind, variant.kind)
@@ -76,6 +84,11 @@ pipeline test(task) {
   }
   let edge_body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859140000,\"webhookId\":\"wh_edge\",\"data\":{\"id\":\"ISS-EDGE\"}}"
   assert_eq(normalize_inbound(raw(edge_body, "test-secret")).type, "event")
+  let bad_timestamp_body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\",\"webhookTimestamp\":\"not-a-number\",\"webhookId\":\"wh_bad_ts\",\"data\":{\"id\":\"ISS-BAD-TS\"}}"
+  let bad_timestamp = normalize_inbound(raw(bad_timestamp_body, "test-secret"))
+  assert_eq(bad_timestamp.type, "reject")
+  assert_eq(bad_timestamp.status, 400)
+  assert(contains(bad_timestamp.body, "invalid_webhook_timestamp"))
   let stale_body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\",\"webhookTimestamp\":1776859139000,\"webhookId\":\"wh_stale\",\"data\":{\"id\":\"ISS-STALE\"}}"
   let stale = normalize_inbound(raw(stale_body, "test-secret"))
   assert_eq(stale.type, "reject")
@@ -85,7 +98,7 @@ pipeline test(task) {
   assert_eq(invalid.type, "reject")
   assert_eq(invalid.status, 401)
   assert(contains(invalid.body, "invalid_signature"))
-  let unsupported_body = trim(read_file("tests/fixtures/webhooks/unsupported_action.json"))
+  let unsupported_body = fixture_text("tests/fixtures/webhooks/unsupported_action.json")
   let unsupported = normalize_inbound(raw(unsupported_body, "test-secret"))
   assert_eq(unsupported.type, "reject")
   assert_eq(unsupported.status, 400)


### PR DESCRIPTION
## Summary
- Route Linear GraphQL outbound calls through Harn shared connector HTTP policy and std/graphql request body helpers.
- Use shared HMAC verification and support additional signing-secret alias locations while rejecting malformed webhook timestamps cleanly.
- Remove deprecated ambient fs usage from fixture tests, add transport-error coverage, and refresh setup metadata/docs for Harn 0.8.32.

## Validation
- harn check src/lib.harn tests/graphql_smoke.harn tests/normalize_smoke.harn
- harn lint src/lib.harn tests/graphql_smoke.harn tests/normalize_smoke.harn
- harn run tests/graphql_smoke.harn
- harn run tests/normalize_smoke.harn
- harn connector test /Users/ksinder/.codex/worktrees/1665/harn-linear-connector --provider linear
- CARGO_TARGET_DIR=/tmp/harn-linear-connector-cargo-target cargo run --manifest-path /Users/ksinder/projects/harn/Cargo.toml --quiet --bin harn -- connector test /Users/ksinder/.codex/worktrees/1665/harn-linear-connector --provider linear