### PR TITLE
Clean up connector docs

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional Harn tag to bump to, for example v0.7.33. Defaults to the latest published release."
+        description: "Optional Harn release tag (vX.Y.Z). Defaults to the latest published release."
         required: false
         type: string
   schedule:
@@ -162,10 +162,10 @@ jobs:
           ## Summary
           - bump the pinned \`harn-cli\` version in \`.harn-version\` to \`${VERSION_NO_V}\`
           - refresh formatter output with \`${VERSION}\`
-          - let the normal CI workflow re-run the Harn checks against the published release
+          - let the normal CI workflow rerun the Harn checks against the published release
 
           ## Verification
-          - GitHub Actions will re-run the repo's Harn CI lanes
+          - GitHub Actions will rerun the repo's Harn CI lanes
           EOF
 
           PR_NUMBER="$(gh pr list --repo "${REPO}" --head "${BRANCH}" --base main --json number --jq '.[0].number // ""')"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS.md
 
-Use `CLAUDE.md` in this repository for provider-specific notes. Shared connector authoring rules
-live in the canonical Harn guide:
+Provider-specific notes live in `CLAUDE.md`.
 
-- https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md
+Shared connector authoring rules live in the canonical Harn guide:
 
-Keep this file as a pointer. Add shared connector guidance to the Harn guide first.
+- <https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md>
+
+Keep this file as a pointer. Put shared connector guidance in the Harn guide first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,23 @@
-# CLAUDE.md - harn-linear-connector
+# CLAUDE.md
 
 Pure-Harn connector package for Linear webhooks and GraphQL outbound calls.
 
 Shared Harn connector authoring rules live in the canonical guide:
 
-- https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md
+- <https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md>
 
-Keep this file limited to provider-specific notes and local hazards. Add shared connector guidance
-to the Harn guide first.
+Keep this file limited to Linear-specific notes and local hazards. Put shared connector guidance in
+the Harn guide first.
 
 ## Provider Notes
 
 - Webhook verification uses `linear-signature` with the Linear webhook secret and enforces the
   provider replay window.
-- Delivery ids come from `linear-delivery`; use them as stable dedupe material when available.
+- Delivery IDs come from `linear-delivery`; use them as stable dedupe material when available.
+- Default secret IDs are `linear/webhook-secret` for webhook verification and `linear/api-token` for
+  outbound API-token auth.
 - Linear has no OpenAPI surface. Keep outbound behavior on Harn `std/graphql` helpers unless a
   separate generated GraphQL SDK package is created.
 - OAuth access tokens use `Authorization: Bearer`; personal API keys use `Authorization: <api_key>`.
+- `search` uses `searchIssues(query:)` first and falls back to `searchIssues(term:)` when a Linear
+  GraphQL schema still expects `term`.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ webhook signatures, enforces Linear's 60-second replay window, normalizes
 Linear event payloads to the canonical `TriggerEvent` shape, and dispatches
 outbound GraphQL queries.
 
-> **Status: pre-alpha** — this repo is a first-party connector package for
-> Harn `0.8.32` or newer. CI installs the pinned CLI version from
-> `.harn-version`.
+> **Status:** pre-alpha. This repo is a first-party connector package for
+> Harn. CI installs the pinned CLI version from [`.harn-version`](./.harn-version).
 
 This is an **inbound + outbound** connector implementing Harn Connector
 Contract v1. The canonical contract docs live in the Harn repo:
@@ -15,11 +14,10 @@ Contract v1. The canonical contract docs live in the Harn repo:
 - [Connector authoring](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md)
 - [Connector architecture](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/architecture.md)
 
-Linear has no OpenAPI spec — its public API is GraphQL. Outbound calls use
+Linear has no OpenAPI spec. Its public API is GraphQL. Outbound calls use
 Harn's `std/graphql` operation/envelope helpers and shared connector HTTP
 policy so query documents, errors, rate-limit metadata, and cursor pagination
-are handled the same way as other GraphQL-first connector packages. A larger
-fully generated `linear-sdk-harn` can build on the same substrate later.
+are handled the same way as other GraphQL-first connector packages.
 
 ## Install
 
@@ -47,7 +45,8 @@ trigger triage on linear {
     events: ["Issue"],
   }
   on event {
-    if event.action == "create" && event.data.priority == 1 {
+    let raw = event.provider_payload.raw
+    if raw.action == "create" && raw.data.priority == 1 {
       linear_connector.call("graphql", {
         query: """
           mutation Comment($issueId: String!, $body: String!) {
@@ -56,7 +55,7 @@ trigger triage on linear {
             }
           }
         """,
-        variables: { issueId: event.data.id, body: "Auto-triaged: urgent." },
+        variables: { issueId: raw.data.id, body: "Auto-triaged: urgent." },
       })
     }
   }
@@ -87,8 +86,8 @@ scripts or private automation. Minimum OAuth scopes depend on the methods used:
 - `read` for `list_issues`, `search`, and read-only `graphql` queries.
 - `write` or narrower write scopes for mutations.
 - `comments:create` is enough for `create_comment`.
-- `issues:create` is only needed if future recipes add issue creation.
-- Avoid `admin`; this connector does not require it for the MVP methods.
+- `issues:create` is only needed for workflows that create issues.
+- Avoid `admin`; these helpers do not require it.
 
 ## Inbound Events
 
@@ -104,7 +103,8 @@ Supported Linear webhook resources are:
 
 Actions are `create`, `update`, and `remove`. Unknown resources are normalized
 with their lower-case resource name; unknown actions are rejected. Dedupe keys
-prefer `Linear-Delivery`, then `webhookId`, then `sha256(raw_body)`.
+prefer `linear:<Linear-Delivery>`, then `linear:<webhookId>`, then
+`linear:sha256:<raw-body-hash>`.
 
 ## Outbound Methods
 
@@ -112,7 +112,7 @@ prefer `Linear-Delivery`, then `webhookId`, then `sha256(raw_body)`.
 `variables`, optional `operation_name` / `operationName`, auth, and optional
 `api_base_url`.
 
-Typed MVP helpers are local to this package:
+Typed helpers are local to this package:
 
 - `list_issues({ filter?, first?, after?, include_archived? })`
 - `update_issue({ id, changes })`
@@ -122,8 +122,8 @@ Typed MVP helpers are local to this package:
 Connection-returning methods preserve Linear pagination data in `pageInfo`.
 Callers should pass `pageInfo.endCursor` as `after` while
 `pageInfo.hasNextPage` is true. `search` uses Linear's `searchIssues` field and
-falls back from the newer `query` argument to the older `term` argument when
-Linear returns a GraphQL validation error.
+falls back to `term` when Linear returns a GraphQL validation error for the
+`query` argument.
 
 GraphQL responses always include `meta` on success. Typed helper return objects
 also receive this `meta` field:
@@ -150,7 +150,7 @@ returns `NormalizeResult` v1:
   cases return `{ type: "reject", status, headers, body }`
 
 Dedupe keys are deterministic. The connector prefers `Linear-Delivery`, then
-`webhookId`, and finally `sha256(raw_body)`. Event kinds are
+`webhookId`, and finally a hash of the raw request body. Event kinds are
 `linear.<resource>.<action>`, for example `linear.issue.update` and
 `linear.comment.create`.
 
@@ -170,9 +170,9 @@ CI installs the pinned Harn CLI from `.harn-version` and runs the same full
 package gate. Local development should use the installed CLI and this package's
 `harn.toml`; it should not depend on a sibling `~/projects/harn` checkout.
 
-The connector contract fixtures include a harn-cloud managed-ingress-shaped
-delivery with `metadata.secret_ids.signing_secret = "linear.webhook.secret"`.
-Harn Cloud maps that alias when the connector calls `secret_get("linear/signing_secret")`,
+The connector contract fixtures include a Harn Cloud managed-ingress delivery
+with `metadata.secret_ids.signing_secret = "linear.webhook.secret"`. Harn Cloud
+maps that alias when the connector calls `secret_get("linear/signing_secret")`,
 so tests cover managed ingress without live provider credentials.
 
 ## License

--- a/harn.toml
+++ b/harn.toml
@@ -159,5 +159,5 @@ body = "{\"action\":\"update\",\"type\":\"Issue\",\"organizationId\":\"org_123\"
 expect_type = "reject"
 expect_event_count = 0
 
-# Harn-side package dependencies live here. This package currently has none.
+# Harn-side package dependencies live here.
 [dependencies]


### PR DESCRIPTION
## Summary
- keep AGENTS.md as a short pointer to CLAUDE.md and the canonical Harn connector authoring guide
- tighten Linear-specific provider notes in CLAUDE.md
- remove stale/time-sensitive README and workflow wording, and align the README example with TriggerEvent provider payload access

## Verification
- git diff --check
- canonical connector guidance guard from CI
- /tmp/harn-cli-0.8.32/bin/harn connector test "$(pwd)" --provider linear
