### PR TITLE
ci: migrate app-id → client-id on create-github-app-token

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
GitHub deprecated the `app-id` input on `actions/create-github-app-token` in favor of `client-id`. Same App, same private key, just the new input name. Org secret `RELEASE_APP_CLIENT_ID` is already set across the org.

Matches burin-labs/burin-code#1086 and burin-labs/harn-cloud#379.