### PR TITLE
ci(bump-harn): fix createCommitOnBranch step on large diffs

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -157,22 +157,34 @@ jobs:
               -f ref="refs/heads/${BRANCH}" -f sha="${BASE_SHA}" >/dev/null
           fi
 
-          ADDITIONS_JSON='[]'
+          # Build additions/deletions as JSONL files. File content goes through
+          # `jq --rawfile` (file -> fd), never through argv, because Linux caps any
+          # single argv element at MAX_ARG_STRLEN (128 KiB); a base64-encoded source
+          # file >96 KiB would otherwise trip E2BIG on execve. The final request uses
+          # `--slurpfile`, which reassembles each JSONL stream into a JSON array via
+          # fd, so the total payload also bypasses ARG_MAX.
+          ADDITIONS_FILE="$(mktemp)"
+          : > "${ADDITIONS_FILE}"
           while IFS= read -r path; do
             [ -n "${path}" ] || continue
             [ -f "${path}" ] || continue
-            CONTENT_B64="$(base64 -w0 < "${path}")"
-            ADDITIONS_JSON="$(jq --arg p "${path}" --arg c "${CONTENT_B64}" \
-              '. + [{path:$p, contents:$c}]' <<<"${ADDITIONS_JSON}")"
+            B64_FILE="$(mktemp)"
+            base64 -w0 < "${path}" > "${B64_FILE}"
+            # rawfile preserves base64's trailing newline; GitHub's decoder rejects
+            # whitespace, so scrub any embedded newlines in jq.
+            jq -nc --arg p "${path}" --rawfile c "${B64_FILE}" \
+              '{path:$p, contents:($c | gsub("\n";""))}' >> "${ADDITIONS_FILE}"
+            rm -f "${B64_FILE}"
           done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD)
 
-          DELETIONS_JSON='[]'
+          DELETIONS_FILE="$(mktemp)"
+          : > "${DELETIONS_FILE}"
           while IFS= read -r path; do
             [ -n "${path}" ] || continue
-            DELETIONS_JSON="$(jq --arg p "${path}" '. + [{path:$p}]' <<<"${DELETIONS_JSON}")"
+            jq -nc --arg p "${path}" '{path:$p}' >> "${DELETIONS_FILE}"
           done < <(git diff --name-only --diff-filter=D HEAD)
 
-          if [ "${ADDITIONS_JSON}" = '[]' ] && [ "${DELETIONS_JSON}" = '[]' ]; then
+          if [ ! -s "${ADDITIONS_FILE}" ] && [ ! -s "${DELETIONS_FILE}" ]; then
             echo "No file changes detected for bump commit; aborting." >&2
             exit 1
           fi
@@ -183,8 +195,8 @@ jobs:
             --arg branch "${BRANCH}" \
             --arg headline "chore: bump Harn runtime to ${VERSION}" \
             --arg oid "${BASE_SHA}" \
-            --argjson additions "${ADDITIONS_JSON}" \
-            --argjson deletions "${DELETIONS_JSON}" \
+            --slurpfile additions "${ADDITIONS_FILE}" \
+            --slurpfile deletions "${DELETIONS_FILE}" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
               variables: {


### PR DESCRIPTION
## Summary
- The bump-harn workflow's `createCommitOnBranch` step passed each file's base64'd content through `jq --arg c` (argv) and the final request through `--argjson additions` (also argv).
- Linux execve caps a single argv element at `MAX_ARG_STRLEN` = 128 KiB and the full cmdline at `ARG_MAX` ≈ 2 MiB. Any source file > 96 KiB (base64 inflates to >128 KiB) trips E2BIG on the per-file jq call; a large aggregate diff trips it on the final assembly.
- The latest fleet bump hit this in `burin-labs/burin-code` on `pack-assembly.harn` (98 KiB raw → 131 KiB base64). Other repos got lucky on file sizes — the latent bug is here too.

## Fix
- Stream additions/deletions through JSONL files using `jq --rawfile` (per file) and `jq --slurpfile` (final assembly). Nothing large goes through argv.
- `--rawfile` preserves base64's trailing newline; `gsub("\n";"")` scrubs it inside the jq filter so GitHub's decoder still accepts the payload.

## Test plan
- [ ] CI green on this PR.
- [ ] Next scheduled or on-demand `bump-harn` dispatch in this repo (or any subsequent Harn release) completes its commit step without E2BIG.