### PR TITLE
ci: pin app token action to v3.2.0

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Mint GitHub App installation token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- pin `actions/create-github-app-token` to the current v3.2.0 commit
- keep the bump workflow on the current Node 24 action release

## Verification
- actionlint .github/workflows/*.yml
- git diff --check
