### PR TITLE
Declare Harn 0.8 compatibility

### DIFF
--- a/harn.toml
+++ b/harn.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "Pure-Harn Linear connector: webhook verification, replay-window enforcement, GraphQL dispatch."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-linear-connector"
+harn = ">=0.8,<0.9"
 
 [exports]
 default = "src/lib.harn"


### PR DESCRIPTION
## Summary
- Declare this connector package compatible with Harn >=0.8,<0.9 in package metadata.
- Leave the package version and connector contract unchanged.

## Validation
- git diff --check
- harn fmt --check src tests
- harn connector test "$(pwd)" --provider linear