### PR TITLE
Normalize bump-harn.yml to fleet canonical

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional Harn release tag (vX.Y.Z). Defaults to the latest published release."
+        description: "Optional Harn release tag. Defaults to the latest published release."
         required: false
         type: string
   schedule:
@@ -49,7 +49,7 @@ jobs:
             VERSION="$(gh api repos/burin-labs/harn/releases/latest --jq '.tag_name')"
           fi
           if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Expected tag like v0.7.33, got '${VERSION}'" >&2
+            echo "Expected Harn release tag vMAJOR.MINOR.PATCH, got '${VERSION}'" >&2
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -124,7 +124,12 @@ jobs:
 
       - name: Format with target Harn
         if: steps.update.outputs.changed == 'true'
-        run: harn fmt src tests
+        run: |
+          set -euo pipefail
+          mapfile -t harn_files < <(git ls-files '*.harn')
+          if [ ${#harn_files[@]} -gt 0 ]; then
+            harn fmt "${harn_files[@]}"
+          fi
 
       - name: Stop when repo is already current
         if: steps.published.outputs.ready == 'true' && steps.update.outputs.changed != 'true'
@@ -234,10 +239,10 @@ jobs:
           ## Summary
           - bump the pinned \`harn-cli\` version in \`.harn-version\` to \`${VERSION_NO_V}\`
           - refresh formatter output with \`${VERSION}\`
-          - let the normal CI workflow rerun the Harn checks against the published release
+          - let the normal CI workflow re-run the Harn checks against the published release
 
           ## Verification
-          - GitHub Actions will rerun the repo's Harn CI lanes
+          - GitHub Actions will re-run the repo's Harn CI lanes
           EOF
 
           PR_NUMBER="$(gh pr list --repo "${REPO}" --head "${BRANCH}" --base main --json number --jq '.[0].number // ""')"


### PR DESCRIPTION
Aligns this repo's Harn auto-bump workflow with the fleet-standard version (generic wording + layout-agnostic fmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)