### PR TITLE
docs: use sentence case for event method headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ scripts or private automation. Minimum OAuth scopes depend on the methods used:
 - `issues:create` is only needed for workflows that create issues.
 - Avoid `admin`; these helpers do not require it.
 
-## Inbound Events
+## Inbound events
 
 Supported Linear webhook resources are:
 
@@ -106,7 +106,7 @@ with their lower-case resource name; unknown actions are rejected. Dedupe keys
 prefer `linear:<Linear-Delivery>`, then `linear:<webhookId>`, then
 `linear:sha256:<raw-body-hash>`.
 
-## Outbound Methods
+## Outbound methods
 
 `call("graphql", args)` is the escape hatch. It accepts `query`, optional
 `variables`, optional `operation_name` / `operationName`, auth, and optional


### PR DESCRIPTION
Uses sentence case for the Inbound events and Outbound methods README sections.\n\nValidation: git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786424989&installation_id=145974243&pr_number=132&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F132&signature=cfa227acf6467ac5647d8e8e094f7fd09790680079a4333448eaf20c3e966de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->