### PR TITLE
docs: correct Linear connector guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # AGENTS.md
 
-Provider-specific notes live in `CLAUDE.md`.
+Provider-specific notes are in [CLAUDE.md](./CLAUDE.md).
 
-Shared connector authoring rules live in the canonical Harn guide:
+Shared connector authoring rules are in Harn's
+[connector authoring guide](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md).
 
-- <https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md>
-
-Keep this file as a pointer. Put shared connector guidance in the Harn guide first.
+Keep this file as a pointer. Put rules shared across connectors in that guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,8 @@
 
 Pure-Harn connector package for Linear webhooks and GraphQL outbound calls.
 
-Shared Harn connector authoring rules live in the canonical guide:
-
-- <https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md>
+Shared Harn connector authoring rules are in the
+[connector authoring guide](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md).
 
 Keep this file limited to Linear-specific notes and local hazards. Put shared connector guidance in
 the Harn guide first.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Supported Linear webhook resources are:
 
 Actions are `create`, `update`, and `remove`. Unknown resources are normalized
 with their lower-case resource name; unknown actions are rejected. Dedupe keys
-prefer `linear:<Linear-Delivery>`, then `linear:<webhookId>`, then
-`linear:sha256:<raw-body-hash>`.
+prefer the signed `linear:<webhookId>`, then `linear:<Linear-Delivery>`, then
+`linear:sha256:<raw-body-hash>`. This prevents a replay from changing an
+unsigned delivery header to bypass deduplication.
 
 ## Outbound methods
 
@@ -149,10 +150,8 @@ returns `NormalizeResult` v1:
 - failed signature, missing timestamp, replay-window, and unsupported-action
   cases return `{ type: "reject", status, headers, body }`
 
-Dedupe keys are deterministic. The connector prefers `Linear-Delivery`, then
-`webhookId`, and finally a hash of the raw request body. Event kinds are
-`linear.<resource>.<action>`, for example `linear.issue.update` and
-`linear.comment.create`.
+Event kinds are `linear.<resource>.<action>`, for example
+`linear.issue.update` and `linear.comment.create`.
 
 Run the local contract and fixture suite with:
 


### PR DESCRIPTION
## Summary
- make the agent docs point to the canonical connector guide and package gate
- correct the webhook dedupe order to prefer the signed `webhookId`
- remove duplicated stale dedupe prose and use sentence-case headings

## Validation
- `harn connector test "$(pwd)" --provider linear`
- `pnpm exec markdownlint-cli2 --config .markdownlint-cli2.jsonc AGENTS.md CLAUDE.md README.md`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786457183&installation_id=145974243&pr_number=134&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F134&signature=ed7a6f5c3a05ec03f8ad76f83f61f88a40fd6ec91e6cc5f65a49358316fb1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->