### PR TITLE
Use a pointer file for CLAUDE.md, not a symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Shared connector authoring rules live in the Harn guide:
 Put shared connector guidance in the Harn guide and keep only
 provider-specific notes and local hazards here.
 
-`CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` only.
+`CLAUDE.md` points here. Edit `AGENTS.md` only.
 
 ## Provider notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
-AGENTS.md
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md). It is the canonical guidance for this repo, and it
+links to the shared [connector authoring guide](https://github.com/burin-labs/harn/blob/main/docs/src/connectors/authoring.md).
+
+This is a regular file rather than a symlink: connector repos are published Harn
+packages, and the package installer rejects symlinks in package content.


### PR DESCRIPTION
## What

`CLAUDE.md` goes back to being a regular one-line pointer file instead of a symlink to `AGENTS.md`.

## Why

Connector repos are published Harn packages, and the package installer rejects symlinks anywhere in package content:

```
error: package content contains unsupported symlink: .../CLAUDE.md
```

The consolidation this follows up on is unaffected — `AGENTS.md` remains the single owner of the guidance, and `CLAUDE.md` carries one sentence pointing at it.

Separately, the installer performs its symlink check *before* its exclusion check, so a symlink at an excluded path is rejected even though the file would never be hashed. Worth fixing upstream in harn; this change does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787538842&installation_model_id=426921&pr_number=151&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F151&signature=dd5abd193666e410aa509b7a65fb7f1dd4e072e25da6a85d9d720dace8b175c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->