### PR TITLE
chore(ci): repin reusable Harn bump

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@7313a4bd8fe95b93239971457513a5adb6d46fcd
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@b316dc7c78792263095a35de807959d3fdee0187
     with:
       version: ${{ inputs.version }}
       validate-command: harn package verify .


### PR DESCRIPTION
Refs burin-labs/harn-bump-fleet#530 and burin-labs/harn#5887.

Pins the existing dispatch-only adapter to the merged Harn workflow fix at b316dc7c78792263095a35de807959d3fdee0187. The reusable workflow now checks the consumer package and target Harn runtime into sibling directories, so package validation cannot recurse into Harn intentional negative fixtures.

Repository-specific inputs and the shared burin-labs/.github package workflow are unchanged.

Verification:
- changed-file scope: .github/workflows/bump-harn.yml only
- immutable owner SHA and workflow blob verified on Harn main
- actionlint
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788195824&installation_model_id=426921&pr_number=157&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F157&signature=1e67c7a7f4e22748d907ef8489f4e2e4b2757d2b092505d1c9c9ec99c0b9ef62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->