### PR TITLE
ci: use generated Harn package workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,15 @@ permissions:
 
 jobs:
   harn:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@c5c3362bd344a549d6e5ed5418d5932405443738
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@a556b40acf7cbb278bd9b25b293fd99603656ef8
 
   ci-status:
     name: CI status
-    if: always()
+    if: ${{ always() }}
     needs: [harn]
     runs-on: ubuntu-latest
     steps:
-      - name: Check for failures
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "Harn package verification failed"
-            exit 1
-          fi
-          echo "Harn package verification passed or was skipped"
+      - name: Enforce required jobs
+        uses: burin-labs/.github/.github/actions/require-successful-needs@a556b40acf7cbb278bd9b25b293fd99603656ef8
+        with:
+          results-json: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
Generated from the typed fleet manifest by burin-labs/harn-bump-fleet#597. This replaces repository-owned Harn installation, verification, and aggregate-status boilerplate with the canonical organization workflow and its co-versioned typed status action. Provider-specific inputs remain manifest-owned. Verified by an exact second render, actionlint, and git diff --check. Refs burin-labs/harn-bump-fleet#596.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788301039&installation_model_id=426921&pr_number=161&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F161&signature=140f016f0d8535bb9032564dae18ac72f4ddc002b9b67814189de5869c407e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->