### PR TITLE
refactor: name capability parameters for the capability they carry

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -151,10 +151,10 @@ fn __is_allowed_secret_id(value) {
   return raw.starts_with("linear/")
 }
 
-fn __secret_ref(harness: HarnessSecrets, value, fallback_id) {
+fn __secret_ref(secrets: HarnessSecrets, value, fallback_id) {
   const raw = trim(to_string(value ?? ""))
   if raw == "" {
-    return harness.read(fallback_id)
+    return secrets.read(fallback_id)
   }
   if !__is_allowed_secret_id(raw) {
     throw {
@@ -162,15 +162,15 @@ fn __secret_ref(harness: HarnessSecrets, value, fallback_id) {
       message: "linear connector secret refs must start with `linear/`",
     }
   }
-  return harness.read(raw)
+  return secrets.read(raw)
 }
 
-fn __auth_token(harness: HarnessSecrets, literal, secret_ref, fallback_id) {
+fn __auth_token(secrets: HarnessSecrets, literal, secret_ref, fallback_id) {
   const raw = trim(to_string(literal ?? ""))
   if raw != "" {
     return raw
   }
-  return __secret_ref(harness, secret_ref, fallback_id)
+  return __secret_ref(secrets, secret_ref, fallback_id)
 }
 
 fn __secret_id_candidate(value, fallback_name) {
@@ -191,12 +191,12 @@ fn __secret_id_candidate(value, fallback_name) {
   return "linear/" + fallback_name
 }
 
-fn __secret_get_optional(harness: HarnessSecrets, secret_id) {
+fn __secret_get_optional(secrets: HarnessSecrets, secret_id) {
   if secret_id == nil {
     return nil
   }
   const value = try {
-    harness.read(secret_id)
+    secrets.read(secret_id)
   }
   if is_ok(value) {
     return unwrap(value)
@@ -204,23 +204,23 @@ fn __secret_get_optional(harness: HarnessSecrets, secret_id) {
   return nil
 }
 
-fn __secret_ref_with_alias(harness: HarnessSecrets, value, fallback_name, fallback_id) {
+fn __secret_ref_with_alias(secrets: HarnessSecrets, value, fallback_name, fallback_id) {
   const candidate = __secret_id_candidate(value, fallback_name)
   if candidate != nil {
-    return __secret_get_optional(harness, candidate)
+    return __secret_get_optional(secrets, candidate)
   }
-  return __secret_get_optional(harness, fallback_id)
+  return __secret_get_optional(secrets, fallback_id)
 }
 
-fn __metadata_secret_alias(harness: HarnessSecrets, raw, name) {
+fn __metadata_secret_alias(secrets: HarnessSecrets, raw, name) {
   const alias = raw?.metadata?.secret_ids?.[name] ?? raw?.metadata?.config?.secret_ids?.[name]
     ?? raw
     ?.config?.secret_ids?.[name]
-  return __secret_get_optional(harness, __secret_id_candidate(alias, name))
+  return __secret_get_optional(secrets, __secret_id_candidate(alias, name))
 }
 
-fn __signing_secret(harness: HarnessSecrets, raw) {
-  const metadata_alias = __metadata_secret_alias(harness, raw, "signing_secret")
+fn __signing_secret(secrets: HarnessSecrets, raw) {
+  const metadata_alias = __metadata_secret_alias(secrets, raw, "signing_secret")
   if metadata_alias != nil {
     return metadata_alias
   }
@@ -230,7 +230,7 @@ fn __signing_secret(harness: HarnessSecrets, raw) {
     return to_string(literal)
   }
   return __secret_ref_with_alias(
-    harness,
+    secrets,
     config?.secrets?.signing_secret ?? config?.secret_ids?.signing_secret,
     "signing_secret",
     __default_signing_secret_id(),
@@ -253,9 +253,9 @@ fn __reject(status, code, message) {
   }
 }
 
-fn __metrics_inc(harness: HarnessObs, name, amount = 1) {
+fn __metrics_inc(obs: HarnessObs, name, amount = 1) {
   const _ = try {
-    harness.metrics_inc(name, amount)
+    obs.metrics_inc(name, amount)
   }
   return nil
 }

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -17,8 +17,8 @@ fn refresh_body(body, fresh_ts_ms) {
   return json_stringify(updated)
 }
 
-fn raw(harness: HarnessClock, body, secret, configured_secret = nil) {
-  const fresh_ts_ms = to_int(harness.now().timestamp * 1000)
+fn raw(clock: HarnessClock, body, secret, configured_secret = nil) {
+  const fresh_ts_ms = to_int(clock.now().timestamp * 1000)
   const refreshed = refresh_body(body, fresh_ts_ms)
   return {
     kind: "webhook",
@@ -32,8 +32,8 @@ fn raw(harness: HarnessClock, body, secret, configured_secret = nil) {
   }
 }
 
-fn cloud_raw(harness: HarnessClock, body, secret) {
-  const fresh_ts_ms = to_int(harness.now().timestamp * 1000)
+fn cloud_raw(clock: HarnessClock, body, secret) {
+  const fresh_ts_ms = to_int(clock.now().timestamp * 1000)
   const refreshed = refresh_body(body, fresh_ts_ms)
   return {
     kind: "webhook",
@@ -52,12 +52,12 @@ fn cloud_raw(harness: HarnessClock, body, secret) {
   }
 }
 
-fn fixture_text(harness: HarnessFs, path) {
-  return trim(harness.read_text(path))
+fn fixture_text(fs: HarnessFs, path) {
+  return trim(fs.read_text(path))
 }
 
-fn fixture_json(harness: HarnessFs, path) {
-  return json_parse(harness.read_text(path))
+fn fixture_json(fs: HarnessFs, path) {
+  return json_parse(fs.read_text(path))
 }
 
 pipeline test(harness: Harness, task) {


### PR DESCRIPTION
Every capability parameter in this package carried a narrow handle
(`HarnessFs`, `HarnessNet`, …) under the name `harness`. The type said the
function holds one capability; the name said it holds root authority, and the
name is what every reader and call site sees.

This renames each one after the capability it carries, and updates every
reference inside the function. **Harn arguments are positional, so no call site
changes** — the public surface is byte-compatible.

```diff
-pub fn socket_mode_ack(harness: HarnessNet, connection, envelope_id, payload = nil) {
-  return harness.http_post(...)
+pub fn socket_mode_ack(net: HarnessNet, connection, envelope_id, payload = nil) {
+  return net.http_post(...)
```

## How this was produced

Mechanically, by `harn fix --apply --safety surface-changing .` using the new
`capability-parameter-name` lint (HARN-LNT-072, burin-labs/harn#6166), then
`harn fmt`. No hand edits.

The repair is withheld wherever the rename is not provably safe from the
function alone — when the capability's name is already bound there, when a
nested callable rebinds either name, or when the name is a module-level
declaration, import, or call target.

## Verification

Applied with the branch build; **verified with the released 0.10.53 binary**,
which is what package CI runs:

- `harn fix --apply` reported `post-apply diagnostics: 0`
- `harn package verify --strict .` exits 0, with no failing check
- no remaining `harness: Harness*` parameters

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788410235&installation_model_id=426921&pr_number=163&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F163&signature=b39b8f479bf3dc6b33500c4947573fe0a88731b25d8627923b87230f54b2ef1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->