### PR TITLE
ci: pin package CI to the release-integrity policy revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   harn:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@c3d3025db6297d736400911029f34f7983744deb
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@c7af1fc6b6a2486f279083aa91e963ab498424ba
 
   ci-status:
     name: CI status
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce required jobs
-        uses: burin-labs/.github/.github/actions/require-successful-needs@c3d3025db6297d736400911029f34f7983744deb
+        uses: burin-labs/.github/.github/actions/require-successful-needs@c7af1fc6b6a2486f279083aa91e963ab498424ba
         with:
           results-json: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
Pins package CI to the shared-workflow revision that carries the release-integrity invariant from burin-labs/.github#36: every `vX.Y.Z` tag must have a published GitHub release behind it.

The state it prevents cannot be repaired in place — a signed tag with nothing behind it burns the version. `harn-github-connector` accumulated two such tags before anyone noticed; an audit found the same shape in several more repositories. All have since been repaired, and this makes the property checked here rather than conventional.

`harn-package.yml` checks the policy actions out at `job.workflow_sha`, so moving the pin is what brings the new check. Generated by `sync_package_ci.harn` from `harn-bump-fleet`'s `fleet.toml`; the pin and the `require-successful-needs` action are co-versioned, which is why both move together.

Verified before opening: every `vX.Y.Z` tag across the 26 package repositories already has a published release, so no repository is expected to go red on this.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788445859&installation_model_id=426921&pr_number=165&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F165&signature=b767dfa31f40be3a0cb0dbcc10c834b238b484e4314997bbb606f220ad25f716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->