### PR TITLE
chore: restore fleet-owned projections

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@0ff3506ddecab325f100a4d7d363e88e91595902
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@788e5dcd9b01bd2da50369962e5b7fbdb25fed25
     with:
       version: ${{ inputs.version }}
       validate-command: harn package verify .


### PR DESCRIPTION
`fleet.toml` in `burin-labs/harn-bump-fleet` owns the exact bytes of the
files below, and they had drifted from it. This pull request restores the
rendered projection; it does not change what the manifest says.

Edit the projection at its owner and let the fleet re-render it. An edit
made here is reverted by the next convergence run.

- `.github/workflows/bump-harn.yml` — fleet.toml bump adapter projection

Repository: `burin-labs/harn-linear-connector`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789110208&installation_model_id=426921&pr_number=179&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F179&signature=69d57624bb24a185b577101b15a7eb1a57a9dbacb72a69e0f79c9785b3435ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->