### PR TITLE
feat(ci): register releases in the package index

### DIFF
--- a/.github/workflows/register-release.yml
+++ b/.github/workflows/register-release.yml
@@ -1,0 +1,33 @@
+name: Register release
+
+# Publishing a release tag and recording it in the Harn package index are two
+# facts that have to agree, and nothing made them agree: `harn publish` is
+# author-invoked and wired into no pipeline here. `@burin/github-connector`
+# served 0.3.0 from the index while v0.8.3 had shipped, for three months, and
+# `@burin/notion-sdk` served 0.1.1 for ten days after v0.2.0
+# (burin-labs/harn-github-connector#289).
+#
+# This repository cuts releases outside CI, so a tag push is the first moment
+# anything observes the release. The mechanism itself lives in
+# burin-labs/harn-packages, which owns what the index should say; this is the
+# one call that tells it a release happened.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: register-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  register:
+    uses: burin-labs/.github/.github/workflows/register-package-release.yml@abe19da003aa7143538c9e0ca076db9a073beca0
+    secrets:
+      RELEASE_APP_CLIENT_ID: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
A release tag and the Harn package index are two facts that have to agree, and nothing made them agree. `harn publish` is author-invoked and wired into no pipeline here, so the index only ever changed when someone remembered: `@burin/github-connector` served 0.3.0 while v0.8.3 had shipped, for three months, and `@burin/notion-sdk` served 0.1.1 for ten days after v0.2.0 (burin-labs/harn-github-connector#289).

This repository cuts releases outside CI, so a tag push is the first moment anything observes a release. This adds one tag-triggered call to the org-hosted trigger; the mechanism itself lives in `burin-labs/harn-packages`, which owns what the index should say and now proposes the corrections it can derive (burin-labs/harn-packages#41).

The token the reusable workflow mints can dispatch the reconciler and read the resulting run; it cannot write the index. No new credential was created: the `RELEASE_APP_*` org secrets already have organization-wide visibility.

Proven end to end already: the reconciler opened and merged burin-labs/harn-packages#42 for `@burin/github-connector` v0.8.4 and v0.8.5, which shipped today and were invisible to the resolver until it did.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789398767&installation_model_id=426921&pr_number=201&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F201&signature=1d6ceb1b52f043fd5f0631b32e7aaaefaf7830f0feae9bb926c1c7ee0f127046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->