### PR TITLE
chore(ci): advance the release-registration pin

### DIFF
--- a/.github/workflows/register-release.yml
+++ b/.github/workflows/register-release.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   register:
-    uses: burin-labs/.github/.github/workflows/register-package-release.yml@abe19da003aa7143538c9e0ca076db9a073beca0
+    uses: burin-labs/.github/.github/workflows/register-package-release.yml@34f656f21137a09d1044144358a205682f1132b9
     secrets:
       RELEASE_APP_CLIENT_ID: ${{ secrets.RELEASE_APP_CLIENT_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Advances the pin on `register-package-release.yml` to pick up burin-labs/.github#57.

The reconcile run a release asks for is now matched by the run name the reconciler gives it, rather than by which run identifier appeared after the dispatch. The old match was exact except in the second between reading the run list and calling the dispatch API, where two packages releasing at once could each adopt the other's run, and a caller could pass on a reconcile that ran before its own tag was visible.

Pin-only change; no behavior in this repository moves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789399489&installation_model_id=426921&pr_number=202&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F202&signature=ea87167c6ced32e3467beb34dfa5f158d67b08622fced90798f95fff74fe430e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->