### PR TITLE
[Docs] Document that this connector does not take external contributions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,48 @@
+# Label taxonomy for harn-linear-connector.
+#
+# The priority, status, and effort categories are the shared org taxonomy and
+# must match burin-labs/.github/.github/labels.yml verbatim. Type labels reuse
+# the repository defaults (bug, enhancement) instead of duplicating them.
+#
+# This file is a record of intent. Applying it to the repository is a settings
+# change and belongs to the founder. See docs/repo-settings-proposal.md.
+
+- name: priority/p0
+  description: Must have, ships before anything else in flight
+  color: b60205
+- name: priority/p1
+  description: High priority
+  color: d93f0b
+- name: priority/p2
+  description: Medium priority
+  color: fbca04
+- name: priority/p3
+  description: Lower priority
+  color: 0e8a16
+
+- name: status/blocked
+  description: Cannot proceed until a named dependency clears
+  color: d93f0b
+- name: status/in-progress
+  description: An agent or engineer is actively working this
+  color: 0e8a16
+- name: status/needs-decision
+  description: Needs a founder or code-owner ruling before work continues
+  color: fbca04
+- name: status/ready
+  description: Scoped and unblocked, ready to pick up
+  color: 0e8a16
+
+- name: effort/small
+  description: Hours
+  color: c2e0c6
+- name: effort/medium
+  description: A day or two
+  color: fbca04
+- name: effort/large
+  description: Multi-day or multi-PR
+  color: d93f0b
+
+- name: area/core
+  description: The Linear connector surface and its fixtures
+  color: 1d76db

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What changed
+
+<!--
+Three to five sentences. Say what you changed and why, in plain language.
+
+Example:
+Inbound webhooks with a valid signature but an unknown event type were
+returning a parse error instead of an ignore result. The normalizer now
+returns an explicit ignore envelope for event types outside the supported
+set, so the orchestrator stops treating a routine unknown event as a
+delivery failure. A fixture covers one supported and one unsupported event
+type. No change to the outbound dispatch surface.
+-->
+
+## Evidence
+
+<!-- The command you ran and what it reported. `harn test` output, a fixture
+that fails before the change and passes after, or a link to the CI run. -->
+
+## Checklist
+
+- [ ] The title follows `[Area] Sentence case summary`.
+- [ ] No edits between the `HARN SHARED AGENT CONTRACT` markers in `AGENTS.md`.
+- [ ] No hand edits to `.github/workflows/ci.yml` or `.github/dependabot.yml`.
+- [ ] Secrets, tokens, and signatures are redacted from every example.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,11 @@ provider-specific notes and local hazards here.
 - "Ship" means landed on main with required deploy and post-merge checks complete.
 
 <!-- END HARN SHARED AGENT CONTRACT -->
+
+## Pull request titles
+
+Use `[Area] Sentence case summary`, for example
+`[connector] Verify the webhook signature before parsing the payload`. The
+summary starts with a capital letter and does not end with a period. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for scope rules and the files this
+repository does not accept hand edits to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ provider-specific notes and local hazards here.
 ## Pull request titles
 
 Use `[Area] Sentence case summary`, for example
-`[connector] Verify the webhook signature before parsing the payload`. The
+`[Connector] Verify the webhook signature before parsing the payload`. The
 summary starts with a capital letter and does not end with a period. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for scope rules and the files this
 repository does not accept hand edits to.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,14 @@ Use `[Area] Sentence case summary`. The area is the part of the repository
 you touched, in square brackets. The summary starts with a capital letter,
 stays in sentence case, and does not end with a period.
 
+Capitalize the area tag exactly as it is written here. The shared
+`pr-title-check` action matches the tag literally, so a lower-case tag
+fails once the check is wired in.
+
 ```
-[connector] Verify the webhook signature before parsing the payload
-[ci] Pin the release workflow to the fleet-managed action
-[docs] Explain the outbound dispatch allowlist
+[Connector] Verify the webhook signature before parsing the payload
+[CI] Pin the release workflow to the fleet-managed action
+[Docs] Explain the outbound dispatch allowlist
 ```
 
 ### Scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to harn-linear-connector
+
+This repository does not accept external contributions.
+
+## Why
+
+`harn-linear-connector` is a generated and fleet-managed connector package. It carries the
+Linear side of the Harn connector contract and almost nothing else. Its
+runtime pin, CI workflow, dependency configuration, and the shared agent
+contract in `AGENTS.md` are all projected here by
+[`burin-labs/harn-bump-fleet`](https://github.com/burin-labs/harn-bump-fleet)
+and are overwritten on the next sync. A pull request against any of them is
+reverted by automation rather than reviewed, so opening one wastes your time.
+
+The connector contract itself, the vocabulary it speaks, and the decision to
+add or change a connector all live in
+[`burin-labs/harn`](https://github.com/burin-labs/harn). That is where the
+work happens.
+
+## Where to go instead
+
+- Found a bug in how this connector handles Linear, or want a connector that
+  does not exist yet? File it on
+  [`burin-labs/harn`](https://github.com/burin-labs/harn/issues) and apply
+  the `area/connectors` label.
+- Include the provider, the payload or API call that misbehaves, and what you
+  expected instead. Redact tokens, signatures, and account identifiers before
+  you paste anything.
+
+Security reports do not belong in a public issue. Follow the org security
+policy at
+[`burin-labs/.github`](https://github.com/burin-labs/.github/blob/main/SECURITY.md).
+
+## If you have write access
+
+Maintainers and agents working in this repository follow one convention.
+
+### Pull request titles
+
+Use `[Area] Sentence case summary`. The area is the part of the repository
+you touched, in square brackets. The summary starts with a capital letter,
+stays in sentence case, and does not end with a period.
+
+```
+[connector] Verify the webhook signature before parsing the payload
+[ci] Pin the release workflow to the fleet-managed action
+[docs] Explain the outbound dispatch allowlist
+```
+
+### Scope
+
+Keep one concern per pull request. Do not edit anything between the
+`<!-- BEGIN HARN SHARED AGENT CONTRACT -->` and
+`<!-- END HARN SHARED AGENT CONTRACT -->` markers in `AGENTS.md`, and do not
+hand-edit `.github/workflows/ci.yml` or `.github/dependabot.yml`. Change the
+fleet template instead.

--- a/docs/repo-settings-proposal.md
+++ b/docs/repo-settings-proposal.md
@@ -1,0 +1,58 @@
+# Repository settings proposal
+
+This is a proposal, not a change. Repository and organization settings belong
+to the founder. Nothing here has been applied.
+
+## Context
+
+`harn-linear-connector` is public so that it gets free hosted CI and so that
+`harn add github.com/burin-labs/harn-linear-connector@<tag>` resolves without
+credentials. It is not public to solicit contributions. Every commit on
+`main` comes from the release bot or the founder, and the repository has no
+external issue or pull request history.
+
+The current settings advertise collaboration surfaces that nobody staffs. An
+outside reader who files an issue here gets silence, which is worse than being
+told plainly where to go.
+
+## Proposed changes
+
+### 1. Disable issues
+
+Issues are enabled and unused. The connector contract and the decision to
+change a connector live in `burin-labs/harn`, and `CONTRIBUTING.md` now
+routes reports there with the `area/connectors` label.
+
+Turning issues off here removes the dead end. It is reversible, and closed
+issues are preserved and stay readable if the tracker is ever re-enabled.
+
+Confirm before applying: this repository has no open issues.
+
+### 2. Leave discussions off
+
+Discussions are already disabled. No change requested. Recorded so a future
+sweep does not enable them by reflex.
+
+### 3. Restrict who can open a pull request against `main`
+
+Outside contributions are not accepted, but a fork can still open a pull
+request, which spends hosted CI minutes on a change that will be closed.
+
+Restrict pull requests targeting `main` to organization members. In GitHub
+terms this is a branch ruleset on `main` with a bypass list limited to the
+org and the release bot, not a change to repository visibility. The package
+must stay publicly readable so `harn add` keeps working.
+
+### 4. Apply the label taxonomy
+
+`.github/labels.yml` records the shared priority, status, and effort
+categories plus a single `area/core`. The labels were created through the
+API during this sweep. The file is the record of what should exist, so a
+later drift check has something to compare against.
+
+## Not proposed
+
+- Archiving the repository. It is still built against and still receives
+  runtime bumps.
+- Making the repository private. That breaks `harn add` for every consumer.
+- Removing the shared agent contract or the fleet-managed CI workflow.


### PR DESCRIPTION
Part of the org-wide repo hygiene sweep. This repository is treated as a
fleet-generated connector scaffold: every commit on `main` is from the release
bot or the founder, there is no external issue or pull request history, and the
package is public so hosted CI is free and `harn add` resolves without
credentials.

## What this adds

- **`CONTRIBUTING.md`** says plainly that external contributions are not
  accepted and why, and routes bug reports and connector requests to
  [`burin-labs/harn`](https://github.com/burin-labs/harn/issues) with the
  `area/connectors` label. That label was verified to exist before linking it.
- **`.github/pull_request_template.md`** with a worked example and a checklist
  covering the files this repository does not accept hand edits to.
- **`.github/labels.yml`** records the shared org priority, status, and effort
  categories verbatim from `burin-labs/.github`, plus a single `area/core`. The
  labels themselves were created through the API, so the file is the record of
  intent rather than the mechanism.
- **`docs/repo-settings-proposal.md`** proposes and does not apply: disabling
  the unused issue tracker, leaving discussions off, and restricting pull
  requests against `main` to organization members. Repository and organization
  settings remain the founder's to change.
- A `[Area] Sentence case` pull request title convention in `CONTRIBUTING.md`,
  with one pointer line appended to `AGENTS.md` after the shared contract.

## What this deliberately does not touch

- Nothing between the `HARN SHARED AGENT CONTRACT` markers in `AGENTS.md`.
- `.github/workflows/ci.yml` and `.github/dependabot.yml`, both org-managed
  projections.
- No repository or organization settings were changed.

## Verification

`.github/labels.yml` parses under `yaml.safe_load`. The `AGENTS.md` diff was
checked to confirm it adds no line inside the shared contract markers.

## Follow-up

`pr-title-check` was not wired in. `burin-labs/.github#84` is still open, so
there is no merge SHA to pin to. Wire it once that lands.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790909366&installation_model_id=426921&pr_number=248&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F248&signature=1ff6bf23f54cc225661ec7ec1c152676f9132aaa59b0ad87d94132aae2fd83db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
