### PR TITLE
[Connector] Discover Linear package tests

### DIFF
--- a/tests/graphql_smoke.harn
+++ b/tests/graphql_smoke.harn
@@ -10,7 +10,7 @@ fn recorded_header(headers: any, name: any) {
   return nil
 }
 
-pipeline test(harness: Harness, task: any) {
+pipeline test_graphql_outbound(harness: Harness, task: any) {
   harness.net.egress_policy({allow: ["api.linear.app"], default: "deny"})
   harness.testing.http_mock_clear()
   harness.testing.http_mock(

--- a/tests/normalize_smoke.harn
+++ b/tests/normalize_smoke.harn
@@ -60,14 +60,14 @@ fn fixture_json(fs: HarnessFs, path: any) {
   return json_parse(fs.read_text(path))
 }
 
-pipeline test(harness: Harness, task: any) {
+pipeline test_normalize_webhooks(harness: Harness, task: any) {
   activate(harness, [{id: "linear.test", kind: "webhook", config: {signing_secret: "test-secret"}}])
   assert_eq(provider_id(), "linear")
   assert_eq(kinds(), ["webhook"])
   assert_eq(payload_schema().harn_schema_name, "LinearEventPayload")
-  const issue_body = fixture_text(harness.fs, "tests/fixtures/webhooks/issue_update.json")
+  const issue_body = fixture_text(harness.fs, "fixtures/webhooks/issue_update.json")
   const issue = normalize_inbound(harness, raw(harness.clock, issue_body, "test-secret"))
-  const snapshot = fixture_json(harness.fs, "tests/fixtures/normalized/issue_update.json")
+  const snapshot = fixture_json(harness.fs, "fixtures/normalized/issue_update.json")
   assert_eq(issue.type, "event")
   assert_eq(issue.event.kind, snapshot.event.kind)
   assert_eq(issue.event.dedupe_key, snapshot.event.dedupe_key)
@@ -82,17 +82,14 @@ pipeline test(harness: Harness, task: any) {
   // the linear-delivery header.
   assert_eq(cloud.event.dedupe_key, "linear:wh_1")
   assert_eq(cloud.event.tenant_id, "tenant-acme")
-  const comment_body = fixture_text(harness.fs, "tests/fixtures/webhooks/comment_create.json")
+  const comment_body = fixture_text(harness.fs, "fixtures/webhooks/comment_create.json")
   const comment = normalize_inbound(harness, raw(harness.clock, comment_body, "test-secret"))
   assert_eq(comment.event.kind, "linear.comment.create")
   assert_eq(comment.event.payload.data.id, "COM-1")
-  const variant_snapshot = fixture_json(
-    harness.fs,
-    "tests/fixtures/normalized/linear_variants.json",
-  )
+  const variant_snapshot = fixture_json(harness.fs, "fixtures/normalized/linear_variants.json")
   const variants = variant_snapshot.variants
   for variant in variants {
-    const body = fixture_text(harness.fs, "tests/fixtures/webhooks/" + variant.fixture + ".json")
+    const body = fixture_text(harness.fs, "fixtures/webhooks/" + variant.fixture + ".json")
     const normalized = normalize_inbound(harness, raw(harness.clock, body, "test-secret"))
     assert_eq(normalized.type, "event")
     assert_eq(normalized.event.kind, variant.kind)
@@ -153,10 +150,7 @@ pipeline test(harness: Harness, task: any) {
   assert_eq(invalid.type, "reject")
   assert_eq(invalid.status, 401)
   assert(contains(invalid.body, "invalid_signature"))
-  const unsupported_body = fixture_text(
-    harness.fs,
-    "tests/fixtures/webhooks/unsupported_action.json",
-  )
+  const unsupported_body = fixture_text(harness.fs, "fixtures/webhooks/unsupported_action.json")
   const unsupported = normalize_inbound(
     harness,
     raw(harness.clock, unsupported_body, "test-secret"),


### PR DESCRIPTION
Single-ask: repair the v0.10.126 fleet proof for this connector by making its existing package tests discoverable.

The two named test pipelines are now discovered by the user-test runner. The webhook fixture paths are also resolved relative to their test files, which is the canonical package-test behavior.

Evidence:
- Negative control before: 0 discovered user tests.
- After: 2 discovered, 2 passed.
- Strict package verification: 11 passed, 0 failed, 1 intentional documentation skip.

This PR remains unarmed for fleet-control admission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-linear-connector/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790927381&installation_model_id=426921&pr_number=250&repository=burin-labs%2Fharn-linear-connector&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-linear-connector%2Fpull%2F250&signature=f98fa1cff0700233ef8fdc4b6d5bfa8e964c0ee3e54f6329427123de5400b3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->